### PR TITLE
docs: Add Bookings Dashboard guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -70,6 +70,7 @@
   * [Create a Booking from a Quote](guides/bookings-operators/create-a-booking-from-a-quote.md)
   * [Passenger Weights](guides/bookings-operators/passenger-weights.md)
   * [Adding a stop between two airports in a Booking](guides/bookings-operators/adding-a-stop-between-two-airports-in-a-booking.md)
+  * [Bookings Dashboard](guides/bookings-operators/bookings-dashboard.md)
 * [Accounting Integration](guides/accounting-integration/README.md)
   * [Xero Integration Setup](guides/accounting-integration/xero-integration-setup.md)
   * [Quickbooks Integration Setup](guides/accounting-integration/quickbooks-integration-setup.md)

--- a/guides/bookings-operators/bookings-dashboard.md
+++ b/guides/bookings-operators/bookings-dashboard.md
@@ -50,7 +50,9 @@ A live feed strip below the summary cards shows the **last 6 events** across all
 * ✈️ **Departed** — Route, aircraft, booking code (detected by FlightAware or confirmed by crew)
 * ✅ **Arrived** — Route, aircraft, booking code (detected by FlightAware or confirmed by crew)
 
-Events appear automatically as they happen — no page refresh required. Departure and arrival events are triggered by **FlightAware webhooks** when your aircraft is detected departing or arriving, or when crew confirm times via the [mobile app](../mobile-app/flight-status.md).
+Events appear automatically as they happen — no page refresh required. Departure and arrival events are triggered by **FlightAware webhooks** when your aircraft is detected departing or arriving, or when crew confirm times via the [mobile app](../mobile-app/flight-status.md). The source (FlightAware or Crew) is shown alongside each event.
+
+When a flight arrives, AeroQuote automatically saves the complete flight track from FlightAware. This track is displayed as a route map on the booking's itinerary card — no manual action required.
 
 <!-- 📸 PLACEHOLDER: Screenshot of the live flight map showing dark theme, position trail, airport markers, and aircraft arrow -->
 <!-- Suggested filename: .gitbook/assets/bookings-dashboard-live-map.png -->
@@ -90,7 +92,7 @@ Bookings with at least one flight currently boarding or airborne. Each card show
 * **Route string** (e.g. YBBN → YSSY)
 * **Crew assigned** and **aircraft registration**
 * **Check-in progress** (e.g. 3/4 passengers)
-* **Departure time** and **ETA** (based on actual departure + flight duration, in the arrival airport's timezone). Times come from FlightAware detection or crew confirmation via the mobile app.
+* **Departure time** and **ETA** — When FlightAware provides an estimated arrival time, it's shown as "ETA (FA)". Otherwise, a calculated ETA based on departure time + flight duration is shown as "ETA (calc)". Times are displayed in the arrival airport's timezone.
 * **Live telemetry** — altitude and speed from FlightAware for airborne flights
 * **Status badges** per flight leg (Boarding, InProgress, Completed)
 
@@ -119,6 +121,14 @@ Confirmed bookings that haven't started yet, ordered by departure time. Shows:
 #### ✅ Recently Completed
 
 Bookings that finished within the **last 2 hours**, then automatically removed. Provides a brief record of today's completed operations.
+
+## Booking Expiry
+
+Bookings that are still in **Confirmed** or **Ground Time** status 24 hours after their last flight has ended are automatically marked as **Expired**. This keeps the dashboard and mobile app uncluttered by clearing out bookings the operator forgot to close.
+
+{% hint style="info" %}
+Expired bookings are **not deleted** — they can be reverted to Confirmed at any time from the booking details page using the **Revert to Confirmed** button. Expired bookings are hidden from the mobile app and the Bookings Dashboard.
+{% endhint %}
 
 ## Auto-Refresh
 

--- a/guides/bookings-operators/bookings-dashboard.md
+++ b/guides/bookings-operators/bookings-dashboard.md
@@ -2,6 +2,10 @@
 
 The Bookings Dashboard is a **real-time operations display** designed to give your team a live overview of all flight activity. It's purpose-built for wall-mounted TVs, dedicated monitors, or a second screen — leave it open and watch your bookings progress through their lifecycle.
 
+<!-- 📸 PLACEHOLDER: Full-width screenshot of the Bookings Dashboard with active flights, map, and activity feed visible -->
+<!-- Suggested filename: .gitbook/assets/bookings-dashboard-hero.png -->
+<!-- Dimensions: 1400x900, captured from a wide browser window in dark mode -->
+
 ## Opening the Dashboard
 
 1. Navigate to **Bookings** from the main menu
@@ -20,6 +24,9 @@ The dashboard uses a dark theme optimised for large displays and low-light envir
 * **LIVE indicator** — green pulsing dot confirms the page is actively polling
 * **Date and live clock** — updates every second, no manual refresh needed
 
+<!-- 📸 PLACEHOLDER: Cropped screenshot of the 4 summary cards (In Progress, Upcoming, Active Legs, Ground Time) -->
+<!-- Suggested filename: .gitbook/assets/bookings-dashboard-summary-cards.png -->
+
 ### Summary Cards
 
 Four cards across the top provide an at-a-glance snapshot:
@@ -31,6 +38,9 @@ Four cards across the top provide an at-a-glance snapshot:
 | **Active Legs** | Currently airborne flight legs vs total legs across all bookings |
 | **Ground Time** | Bookings waiting between flight legs (e.g. overnight stops) |
 
+<!-- 📸 PLACEHOLDER: Cropped screenshot of the activity feed showing check-in, departure, and arrival events -->
+<!-- Suggested filename: .gitbook/assets/bookings-dashboard-activity-feed.png -->
+
 ### Activity Feed
 
 A live feed strip below the summary cards shows the **last 6 events** across all bookings:
@@ -41,6 +51,9 @@ A live feed strip below the summary cards shows the **last 6 events** across all
 * ✅ **Arrived** — Route, aircraft, booking code
 
 Events appear automatically as they happen — no page refresh required.
+
+<!-- 📸 PLACEHOLDER: Screenshot of the live flight map showing dark theme, position trail, airport markers, and aircraft arrow -->
+<!-- Suggested filename: .gitbook/assets/bookings-dashboard-live-map.png -->
 
 ### Live Flight Map
 
@@ -61,6 +74,9 @@ The map requires a valid Google Maps API key. If the map appears as a grey box, 
 
 Bookings are organised into four sections, each with colour-coded cards:
 
+<!-- 📸 PLACEHOLDER: Screenshot of an In Progress booking card showing route, crew, check-in count, ETA, altitude/speed, and status badge -->
+<!-- Suggested filename: .gitbook/assets/bookings-dashboard-card-inprogress.png -->
+
 #### 🔵 In Progress
 
 Bookings with at least one flight currently boarding or airborne. Each card shows:
@@ -72,6 +88,9 @@ Bookings with at least one flight currently boarding or airborne. Each card show
 * **Departure time** and **ETA** (based on actual departure + flight duration, in the arrival airport's timezone)
 * **Live telemetry** — altitude and speed for airborne flights
 * **Status badges** per flight leg (Boarding, InProgress, Completed)
+
+<!-- 📸 PLACEHOLDER: Screenshot of a Ground Time booking card showing completed outbound leg and upcoming return leg -->
+<!-- Suggested filename: .gitbook/assets/bookings-dashboard-card-groundtime.png -->
 
 #### 🟠 Ground Time
 
@@ -106,6 +125,10 @@ The dashboard respects existing booking permissions:
 
 * **bookings.view** — Can see bookings they are assigned to as crew
 * **bookings.view-all** — Can see all bookings for the operator
+
+<!-- 📸 PLACEHOLDER: Photo or mockup of the Bookings Dashboard displayed on a wall-mounted TV in an ops room setting -->
+<!-- Suggested filename: .gitbook/assets/bookings-dashboard-tv-mockup.png -->
+<!-- This could be a real photo or a device-frame mockup showing the dashboard on a large screen -->
 
 ## Tips for Ops Rooms
 

--- a/guides/bookings-operators/bookings-dashboard.md
+++ b/guides/bookings-operators/bookings-dashboard.md
@@ -1,0 +1,115 @@
+# Bookings Dashboard
+
+The Bookings Dashboard is a **real-time operations display** designed to give your team a live overview of all flight activity. It's purpose-built for wall-mounted TVs, dedicated monitors, or a second screen — leave it open and watch your bookings progress through their lifecycle.
+
+## Opening the Dashboard
+
+1. Navigate to **Bookings** from the main menu
+2. Click the **Bookings Dashboard** button (top-right of the bookings list)
+3. The dashboard opens in a **new browser tab** — full-screen, no navigation
+
+{% hint style="info" %}
+The dashboard uses a dark theme optimised for large displays and low-light environments like ops rooms.
+{% endhint %}
+
+## Layout
+
+### Header
+
+* **AeroQuote logo** and "Bookings Dashboard" title
+* **LIVE indicator** — green pulsing dot confirms the page is actively polling
+* **Date and live clock** — updates every second, no manual refresh needed
+
+### Summary Cards
+
+Four cards across the top provide an at-a-glance snapshot:
+
+| Card | Description |
+| --- | --- |
+| **In Progress** | Number of bookings with active flights (boarding, airborne) |
+| **Upcoming** | Number of confirmed bookings that haven't started yet |
+| **Active Legs** | Currently airborne flight legs vs total legs across all bookings |
+| **Ground Time** | Bookings waiting between flight legs (e.g. overnight stops) |
+
+### Activity Feed
+
+A live feed strip below the summary cards shows the **last 6 events** across all bookings:
+
+* 👤 **Passenger check-ins** — Name, flight route, booking code
+* 🚪 **Boarding commenced** — Route, aircraft registration
+* ✈️ **Departed** — Route, aircraft, booking code
+* ✅ **Arrived** — Route, aircraft, booking code
+
+Events appear automatically as they happen — no page refresh required.
+
+### Live Flight Map
+
+When any flight is airborne, an interactive map appears showing:
+
+* **Blue markers** — Departure airports
+* **Green markers** — Arrival airports
+* **Orange arrow** — Current aircraft position and heading
+* **Blue trail line** — Flight path so far (position history)
+
+The map uses a dark theme to match the dashboard and updates every 10 seconds.
+
+{% hint style="warning" %}
+The map requires a valid Google Maps API key. If the map appears as a grey box, check your API key configuration in Settings.
+{% endhint %}
+
+### Booking Sections
+
+Bookings are organised into four sections, each with colour-coded cards:
+
+#### 🔵 In Progress
+
+Bookings with at least one flight currently boarding or airborne. Each card shows:
+
+* **Booking code** (links to the individual booking)
+* **Route string** (e.g. YBBN → YSSY)
+* **Crew assigned** and **aircraft registration**
+* **Check-in progress** (e.g. 3/4 passengers)
+* **Departure time** and **ETA** (based on actual departure + flight duration, in the arrival airport's timezone)
+* **Live telemetry** — altitude and speed for airborne flights
+* **Status badges** per flight leg (Boarding, InProgress, Completed)
+
+#### 🟠 Ground Time
+
+Multi-leg bookings where all current flights have landed but future legs are scheduled. For example, a return flight departing the next day. The card shows:
+
+* "Next leg in X hours" — countdown to the next scheduled departure
+* Completed legs with actual arrival times
+* Upcoming legs with scheduled departure times
+
+{% hint style="info" %}
+**Ground Time** is an automatic status. When a flight leg completes and the booking has future legs, the booking transitions to Ground Time. When the next leg's boarding begins, it returns to In Progress.
+{% endhint %}
+
+#### 🟡 Upcoming
+
+Confirmed bookings that haven't started yet, ordered by departure time. Shows:
+
+* Scheduled departure time and "Departs in X" countdown
+* Route, crew, aircraft, and passenger count
+
+#### ✅ Recently Completed
+
+Bookings that finished within the **last 2 hours**, then automatically removed. Provides a brief record of today's completed operations.
+
+## Auto-Refresh
+
+The dashboard automatically refreshes every **10 seconds**. There is no need to manually reload the page. All sections — summary cards, activity feed, map, and booking cards — update together.
+
+## Permissions
+
+The dashboard respects existing booking permissions:
+
+* **bookings.view** — Can see bookings they are assigned to as crew
+* **bookings.view-all** — Can see all bookings for the operator
+
+## Tips for Ops Rooms
+
+* **Full-screen mode** — Press `F11` (Windows) or `⌘ Ctrl F` (Mac) for a true full-screen experience
+* **Prevent sleep** — Configure your display to stay awake, or use a "keep awake" browser extension
+* **Multiple monitors** — Open the dashboard on a dedicated screen while using the main AeroQuote app on another
+* **Session timeout** — The page includes an auto-refresh meta tag to keep the session alive during the configured session lifetime

--- a/guides/bookings-operators/bookings-dashboard.md
+++ b/guides/bookings-operators/bookings-dashboard.md
@@ -47,10 +47,10 @@ A live feed strip below the summary cards shows the **last 6 events** across all
 
 * 👤 **Passenger check-ins** — Name, flight route, booking code
 * 🚪 **Boarding commenced** — Route, aircraft registration
-* ✈️ **Departed** — Route, aircraft, booking code
-* ✅ **Arrived** — Route, aircraft, booking code
+* ✈️ **Departed** — Route, aircraft, booking code (detected by FlightAware or confirmed by crew)
+* ✅ **Arrived** — Route, aircraft, booking code (detected by FlightAware or confirmed by crew)
 
-Events appear automatically as they happen — no page refresh required.
+Events appear automatically as they happen — no page refresh required. Departure and arrival events are triggered by **FlightAware webhooks** when your aircraft is detected departing or arriving, or when crew confirm times via the [mobile app](../mobile-app/flight-status.md).
 
 <!-- 📸 PLACEHOLDER: Screenshot of the live flight map showing dark theme, position trail, airport markers, and aircraft arrow -->
 <!-- Suggested filename: .gitbook/assets/bookings-dashboard-live-map.png -->
@@ -62,9 +62,14 @@ When any flight is airborne, an interactive map appears showing:
 * **Blue markers** — Departure airports
 * **Green markers** — Arrival airports
 * **Orange arrow** — Current aircraft position and heading
-* **Blue trail line** — Flight path so far (position history)
+* **Blue trail line** — Actual flight path from FlightAware position data
+* **Dashed grey line** — Planned route (shown for flights without position data yet)
 
-The map uses a dark theme to match the dashboard and updates every 10 seconds.
+Position data is sourced from **FlightAware** via ADS-B tracking. The map uses a dark theme to match the dashboard and updates every 10 seconds.
+
+{% hint style="info" %}
+Flight tracking must be enabled in **Settings → Integrations** for position data to appear. See the [Integrations](../settings/integrations.md) guide for setup.
+{% endhint %}
 
 {% hint style="warning" %}
 The map requires a valid Google Maps API key. If the map appears as a grey box, check your API key configuration in Settings.
@@ -85,8 +90,8 @@ Bookings with at least one flight currently boarding or airborne. Each card show
 * **Route string** (e.g. YBBN → YSSY)
 * **Crew assigned** and **aircraft registration**
 * **Check-in progress** (e.g. 3/4 passengers)
-* **Departure time** and **ETA** (based on actual departure + flight duration, in the arrival airport's timezone)
-* **Live telemetry** — altitude and speed for airborne flights
+* **Departure time** and **ETA** (based on actual departure + flight duration, in the arrival airport's timezone). Times come from FlightAware detection or crew confirmation via the mobile app.
+* **Live telemetry** — altitude and speed from FlightAware for airborne flights
 * **Status badges** per flight leg (Boarding, InProgress, Completed)
 
 <!-- 📸 PLACEHOLDER: Screenshot of a Ground Time booking card showing completed outbound leg and upcoming return leg -->

--- a/guides/bookings-operators/bookings-dashboard.md
+++ b/guides/bookings-operators/bookings-dashboard.md
@@ -4,13 +4,13 @@ The Bookings Dashboard is a **real-time operations display** designed to give yo
 
 ## Opening the Dashboard
 
-The Bookings Dashboard is accessed from the **operator dashboard** (Home page):
+The Bookings Dashboard is accessed from the **Bookings card** on the operator Home page:
 
 1. Log in to AeroQuote
-2. On the Home page, look for the **Bookings Dashboard** launch banner below the summary cards
-3. Click the banner — the dashboard opens in a **new browser tab**
+2. On the Home page, find the **Bookings** summary card (shows total bookings, in-progress count, and upcoming count)
+3. Click the **Dashboard** link (with TV icon) on the right side of the card footer — it opens in a **new browser tab**
 
-The launch banner is only visible to users with **Manager**, **Account Administrator**, or **Chief Pilot** roles (users with the `bookings.view-all` permission). Crew members with basic `bookings.view` cannot access the dashboard.
+The Dashboard link is only visible to users with **Manager**, **Account Administrator**, or **Chief Pilot** roles (users with the `bookings.view-all` permission). Crew members with basic `bookings.view` can see the Bookings card but not the Dashboard link.
 
 {% hint style="info" %}
 The dashboard uses a dark theme optimised for large displays and low-light environments like ops rooms.

--- a/guides/bookings-operators/bookings-dashboard.md
+++ b/guides/bookings-operators/bookings-dashboard.md
@@ -76,12 +76,23 @@ The map occupies the **left half of the screen** and adapts based on flight stat
 * **Blue trail line** — Actual flight path from position tracking data
 * **Dashed grey line** — Planned route (shown for flights without position data yet)
 
-#### When no flights are airborne ("Upcoming Routes")
+#### When aircraft are on the ground between legs ("Ground Time")
+
+For multi-leg bookings in ground time, the map shows the full journey context:
+
+* **Dimmed grey trail** — Completed leg's flight path (faded to show it's finished)
+* **Orange aircraft marker** — Aircraft position at the current airport, with registration label
+* **Dashed green line** — Route to the next destination
+* **Green destination marker** — Next arrival airport (slightly larger to draw attention)
+
+This ensures the map stays visible between legs rather than disappearing while the aircraft is on the ground.
+
+#### When no flights are airborne or on ground ("Upcoming Routes")
 
 * **Muted airport markers** — All departure and arrival airports for upcoming bookings
 * **Dashed amber lines** — Planned routes for all upcoming flights, giving a visual overview of what's ahead
 
-The map automatically transitions between these modes as flights depart and arrive.
+The map automatically transitions between these three modes as flights depart, land, and enter ground time.
 
 Position data is sourced from **FlightRadar24** via ADS-B tracking. The map uses a dark theme to match the dashboard.
 
@@ -118,8 +129,10 @@ Multi-leg bookings where all current flights have landed but future legs are sch
 * Completed legs with actual arrival times
 * Upcoming legs with scheduled departure times
 
+The **flight map** remains visible during ground time, showing the completed leg's trail and a dashed line to the next destination — see [Flight Map](#flight-map) above.
+
 {% hint style="info" %}
-**Ground Time** is an automatic status. When a flight leg completes and the booking has future legs, the booking transitions to Ground Time. When the next leg's boarding begins, it returns to In Progress.
+**Ground Time** is an automatic status. When a flight leg completes and the booking has future legs, the booking transitions to Ground Time. When the next leg's boarding or check-in begins, it returns to In Progress.
 {% endhint %}
 
 #### 🟡 Upcoming
@@ -138,11 +151,30 @@ Bookings that finished within the **last 2 hours**, then automatically removed. 
 When flight tracking is enabled, AeroQuote automatically detects key flight events via **FlightRadar24**:
 
 * **Block off** — Detected when the aircraft begins taxiing (ground movement detected)
-* **Departure** — Detected when the aircraft becomes airborne
-* **Arrival** — Detected when the aircraft lands near the destination airport
+* **Departure** — Detected when the aircraft becomes airborne (a dedicated departure seeker polls every 2 minutes after block off until takeoff is confirmed)
+* **ETA updates** — In-flight estimated arrival time updated at key milestones (⅓, ½, and ⅔ of the flight)
+* **Arrival** — Detected when the aircraft lands near the destination airport, or when it disappears from the live feed after the expected flight duration
 * **Block on** — Estimated after arrival
 
 Crew can always override auto-detected times via the mobile app — **crew-confirmed times always take precedence** over automated tracking.
+
+### Multi-leg sequencing
+
+For bookings with multiple flight legs, AeroQuote automatically sequences departure detection. Polling for the next leg's departure **does not begin until the preceding leg has arrived or is on blocks**. This prevents false detections when the aircraft is still airborne on an earlier leg.
+
+### Aircraft tracking identifier
+
+AeroQuote resolves which identifier to use for FlightRadar24 lookups in this order:
+
+1. **Assigned registration** — Set per flight leg (useful when a generic aircraft is assigned a specific tail number closer to departure)
+2. **Aircraft registration** — The registration from the aircraft record
+3. **Flight number** — A callsign like QF1924 (used when no registration is available)
+
+Both flight number and assigned registration can be set from the **Flight Details** panel on a booking's itinerary.
+
+### Disabling tracking per aircraft
+
+FlightRadar24 tracking can be disabled for individual aircraft from the **Aircraft Details** page using the **FlightRadar24 Tracking** toggle. When disabled, AeroQuote will not poll FR24 for that aircraft's flights — useful for aircraft that are not visible on FlightRadar24 or where tracking is not desired.
 
 ## Booking Expiry
 

--- a/guides/bookings-operators/bookings-dashboard.md
+++ b/guides/bookings-operators/bookings-dashboard.md
@@ -18,6 +18,13 @@ The dashboard uses a dark theme optimised for large displays and low-light envir
 
 ## Layout
 
+The dashboard uses a **split-screen layout**:
+
+* **Left half** — Interactive flight map (live tracking or upcoming routes)
+* **Right half** — Scrollable list of all booking cards, grouped by status
+
+When there are no active or upcoming bookings, the map is hidden and booking cards take the full width.
+
 ### Header
 
 * **AeroQuote logo** and "Bookings Dashboard" title
@@ -47,39 +54,44 @@ A live feed strip below the summary cards shows the **last 6 events** across all
 
 * 👤 **Passenger check-ins** — Name, flight route, booking code
 * 🚪 **Boarding commenced** — Route, aircraft registration
-* ✈️ **Departed** — Route, aircraft, booking code (detected by FlightAware or confirmed by crew)
-* ✅ **Arrived** — Route, aircraft, booking code (detected by FlightAware or confirmed by crew)
+* ✈️ **Departed** — Route, aircraft, booking code (auto-detected or confirmed by crew)
+* ✅ **Arrived** — Route, aircraft, booking code (auto-detected or confirmed by crew)
 
-Events appear automatically as they happen — no page refresh required. Departure and arrival events are triggered by **FlightAware webhooks** when your aircraft is detected departing or arriving, or when crew confirm times via the [mobile app](../mobile-app/flight-status.md). The source (FlightAware or Crew) is shown alongside each event.
+Events appear automatically as they happen — no page refresh required. Departure and arrival events are auto-detected via **FlightRadar24** position tracking, or when crew confirm times via the [mobile app](../mobile-app/flight-status.md). The source (e.g. FlightRadar24, Crew confirmed) is shown alongside each event.
 
-When a flight arrives, AeroQuote automatically saves the complete flight track from FlightAware. This track is displayed as a route map on the booking's itinerary card — no manual action required.
+When a flight arrives, AeroQuote automatically saves the complete flight track. This track is displayed as a route map on the booking's itinerary card — no manual action required.
 
 <!-- 📸 PLACEHOLDER: Screenshot of the live flight map showing dark theme, position trail, airport markers, and aircraft arrow -->
 <!-- Suggested filename: .gitbook/assets/bookings-dashboard-live-map.png -->
 
-### Live Flight Map
+### Flight Map
 
-When any flight is airborne, an interactive map appears showing:
+The map occupies the **left half of the screen** and adapts based on flight status:
+
+#### When flights are airborne ("Live Flight Map")
 
 * **Blue markers** — Departure airports
 * **Green markers** — Arrival airports
-* **Orange arrow** — Current aircraft position and heading
-* **Blue trail line** — Actual flight path from FlightAware position data
+* **Orange arrow** — Current aircraft position and heading, with registration label
+* **Blue trail line** — Actual flight path from position tracking data
 * **Dashed grey line** — Planned route (shown for flights without position data yet)
 
-Position data is sourced from **FlightAware** via ADS-B tracking. The map uses a dark theme to match the dashboard and updates every 10 seconds.
+#### When no flights are airborne ("Upcoming Routes")
+
+* **Muted airport markers** — All departure and arrival airports for upcoming bookings
+* **Dashed amber lines** — Planned routes for all upcoming flights, giving a visual overview of what's ahead
+
+The map automatically transitions between these modes as flights depart and arrive.
+
+Position data is sourced from **FlightRadar24** via ADS-B tracking. The map uses a dark theme to match the dashboard.
 
 {% hint style="info" %}
 Flight tracking must be enabled in **Settings → Integrations** for position data to appear. See the [Integrations](../settings/integrations.md) guide for setup.
 {% endhint %}
 
-{% hint style="warning" %}
-The map requires a valid Google Maps API key. If the map appears as a grey box, check your API key configuration in Settings.
-{% endhint %}
+### Booking Cards
 
-### Booking Sections
-
-Bookings are organised into four sections, each with colour-coded cards:
+All booking cards are displayed on the **right half of the screen** in a scrollable list, ordered by status:
 
 <!-- 📸 PLACEHOLDER: Screenshot of an In Progress booking card showing route, crew, check-in count, ETA, altitude/speed, and status badge -->
 <!-- Suggested filename: .gitbook/assets/bookings-dashboard-card-inprogress.png -->
@@ -88,12 +100,11 @@ Bookings are organised into four sections, each with colour-coded cards:
 
 Bookings with at least one flight currently boarding or airborne. Each card shows:
 
-* **Booking code** (links to the individual booking)
-* **Route string** (e.g. YBBN → YSSY)
+* **Booking code** and **route string** (e.g. YBBN → YSSY)
 * **Crew assigned** and **aircraft registration**
 * **Check-in progress** (e.g. 3/4 passengers)
-* **Departure time** and **ETA** — When FlightAware provides an estimated arrival time, it's shown as "ETA (FA)". Otherwise, a calculated ETA based on departure time + flight duration is shown as "ETA (calc)". Times are displayed in the arrival airport's timezone.
-* **Live telemetry** — altitude and speed from FlightAware for airborne flights
+* **Departure time** and **ETA** — When FlightRadar24 provides an estimated arrival time, the source is shown (e.g. "ETA FlightRadar24"). Otherwise, a calculated ETA based on departure time + flight duration is shown as "ETA (calc)". Times are displayed in the arrival airport's timezone.
+* **Live telemetry** — altitude and speed for airborne flights
 * **Status badges** per flight leg (Boarding, InProgress, Completed)
 
 <!-- 📸 PLACEHOLDER: Screenshot of a Ground Time booking card showing completed outbound leg and upcoming return leg -->
@@ -122,6 +133,17 @@ Confirmed bookings that haven't started yet, ordered by departure time. Shows:
 
 Bookings that finished within the **last 2 hours**, then automatically removed. Provides a brief record of today's completed operations.
 
+## Automatic Flight Tracking
+
+When flight tracking is enabled, AeroQuote automatically detects key flight events via **FlightRadar24**:
+
+* **Block off** — Detected when the aircraft begins taxiing (ground movement detected)
+* **Departure** — Detected when the aircraft becomes airborne
+* **Arrival** — Detected when the aircraft lands near the destination airport
+* **Block on** — Estimated after arrival
+
+Crew can always override auto-detected times via the mobile app — **crew-confirmed times always take precedence** over automated tracking.
+
 ## Booking Expiry
 
 Bookings that are still in **Confirmed** or **Ground Time** status 24 hours after their last flight has ended are automatically marked as **Expired**. This keeps the dashboard and mobile app uncluttered by clearing out bookings the operator forgot to close.
@@ -132,7 +154,7 @@ Expired bookings are **not deleted** — they can be reverted to Confirmed at an
 
 ## Auto-Refresh
 
-The dashboard automatically refreshes every **10 seconds**. There is no need to manually reload the page. All sections — summary cards, activity feed, map, and booking cards — update together.
+The dashboard automatically refreshes every **60 seconds**. There is no need to manually reload the page. All sections — summary cards, activity feed, map, and booking cards — update together.
 
 ## Permissions
 

--- a/guides/bookings-operators/bookings-dashboard.md
+++ b/guides/bookings-operators/bookings-dashboard.md
@@ -2,15 +2,15 @@
 
 The Bookings Dashboard is a **real-time operations display** designed to give your team a live overview of all flight activity. It's purpose-built for wall-mounted TVs, dedicated monitors, or a second screen — leave it open and watch your bookings progress through their lifecycle.
 
-<!-- 📸 PLACEHOLDER: Full-width screenshot of the Bookings Dashboard with active flights, map, and activity feed visible -->
-<!-- Suggested filename: .gitbook/assets/bookings-dashboard-hero.png -->
-<!-- Dimensions: 1400x900, captured from a wide browser window in dark mode -->
-
 ## Opening the Dashboard
 
-1. Navigate to **Bookings** from the main menu
-2. Click the **Bookings Dashboard** button (top-right of the bookings list)
-3. The dashboard opens in a **new browser tab** — full-screen, no navigation
+The Bookings Dashboard is accessed from the **operator dashboard** (Home page):
+
+1. Log in to AeroQuote
+2. On the Home page, look for the **Bookings Dashboard** launch banner below the summary cards
+3. Click the banner — the dashboard opens in a **new browser tab**
+
+The launch banner is only visible to users with **Manager**, **Account Administrator**, or **Chief Pilot** roles (users with the `bookings.view-all` permission). Crew members with basic `bookings.view` cannot access the dashboard.
 
 {% hint style="info" %}
 The dashboard uses a dark theme optimised for large displays and low-light environments like ops rooms.
@@ -18,21 +18,19 @@ The dashboard uses a dark theme optimised for large displays and low-light envir
 
 ## Layout
 
-The dashboard uses a **split-screen layout**:
+The dashboard layout consists of:
 
-* **Left half** — Interactive flight map (live tracking or upcoming routes)
-* **Right half** — Scrollable list of all booking cards, grouped by status
-
-When there are no active or upcoming bookings, the map is hidden and booking cards take the full width.
+1. **Header** — Logo, live clock, LIVE indicator
+2. **Summary Cards** — Four at-a-glance stats
+3. **Highlighted Booking** — Featured in-progress booking card (above the map)
+4. **Flight Map** — Full-width interactive map
+5. **Booking Cards** — Ground Time, Upcoming, and Recently Completed in a 3-column grid below the map
 
 ### Header
 
 * **AeroQuote logo** and "Bookings Dashboard" title
 * **LIVE indicator** — green pulsing dot confirms the page is actively polling
 * **Date and live clock** — updates every second, no manual refresh needed
-
-<!-- 📸 PLACEHOLDER: Cropped screenshot of the 4 summary cards (In Progress, Upcoming, Active Legs, Ground Time) -->
-<!-- Suggested filename: .gitbook/assets/bookings-dashboard-summary-cards.png -->
 
 ### Summary Cards
 
@@ -45,30 +43,43 @@ Four cards across the top provide an at-a-glance snapshot:
 | **Active Legs** | Currently airborne flight legs vs total legs across all bookings |
 | **Ground Time** | Bookings waiting between flight legs (e.g. overnight stops) |
 
-<!-- 📸 PLACEHOLDER: Cropped screenshot of the activity feed showing check-in, departure, and arrival events -->
-<!-- Suggested filename: .gitbook/assets/bookings-dashboard-activity-feed.png -->
+## Booking Rotation
 
-### Activity Feed
+When **multiple bookings are in progress** simultaneously, the dashboard automatically cycles through them every **10 seconds**:
 
-A live feed strip below the summary cards shows the **last 6 events** across all bookings:
+* A **highlighted booking card** appears above the map showing full flight details
+* The **map zooms** to show only that booking's airports and flight trail
+* A **progress bar** at the top of the card shows the rotation countdown
+* **Dot indicators** below the card let you manually jump to a specific booking
+* All other bookings' markers remain visible on the map but don't affect the zoom
 
-* 👤 **Passenger check-ins** — Name, flight route, booking code
-* 🚪 **Boarding commenced** — Route, aircraft registration
-* ✈️ **Departed** — Route, aircraft, booking code (auto-detected or confirmed by crew)
-* ✅ **Arrived** — Route, aircraft, booking code (auto-detected or confirmed by crew)
+When only **one booking** is in progress, the highlighted card is shown without rotation.
 
-Events appear automatically as they happen — no page refresh required. Departure and arrival events are auto-detected via **FlightRadar24** position tracking, or when crew confirm times via the [mobile app](../mobile-app/flight-status.md). The source (e.g. FlightRadar24, Crew confirmed) is shown alongside each event.
+## Activity Feed
 
-When a flight arrives, AeroQuote automatically saves the complete flight track. This track is displayed as a route map on the booking's itinerary card — no manual action required.
+Recent activity is displayed as a **popup modal** that appears automatically when the page loads:
 
-<!-- 📸 PLACEHOLDER: Screenshot of the live flight map showing dark theme, position trail, airport markers, and aircraft arrow -->
-<!-- Suggested filename: .gitbook/assets/bookings-dashboard-live-map.png -->
+* Shows the **last 6 events** across all bookings
+* **Auto-dismisses after 10 seconds** with a progress bar countdown
+* Can be dismissed early with the **X button** or by clicking outside
+* Shows only once per page load
 
-### Flight Map
+Activity events include:
 
-The map occupies the **left half of the screen** and adapts based on flight status:
+* **Passenger check-ins** — Name, flight route, booking code
+* **Boarding commenced** — Route, aircraft registration
+* **Departed** — Route, aircraft, booking code (auto-detected or confirmed by crew)
+* **Arrived** — Route, aircraft, booking code (auto-detected or confirmed by crew)
 
-#### When flights are airborne ("Live Flight Map")
+When an **Arrived** event is shown for a recently completed booking with saved flight track data, the **actual flight track map** is displayed below the event list — showing the real path flown as captured by FlightRadar24.
+
+Events from **recently completed bookings** (within the last 2 hours) are included in the feed, so "Arrived" events don't disappear immediately when a booking transitions to Completed status.
+
+## Flight Map
+
+The map is **full-width** and adapts based on flight status:
+
+### When flights are airborne ("Live Flight Map")
 
 * **Blue markers** — Departure airports
 * **Green markers** — Arrival airports
@@ -76,7 +87,7 @@ The map occupies the **left half of the screen** and adapts based on flight stat
 * **Blue trail line** — Actual flight path from position tracking data
 * **Dashed grey line** — Planned route (shown for flights without position data yet)
 
-#### When aircraft are on the ground between legs ("Ground Time")
+### When aircraft are on the ground between legs ("Ground Time")
 
 For multi-leg bookings in ground time, the map shows the full journey context:
 
@@ -85,123 +96,98 @@ For multi-leg bookings in ground time, the map shows the full journey context:
 * **Dashed green line** — Route to the next destination
 * **Green destination marker** — Next arrival airport (slightly larger to draw attention)
 
-This ensures the map stays visible between legs rather than disappearing while the aircraft is on the ground.
-
-#### When no flights are airborne or on ground ("Upcoming Routes")
+### When no flights are airborne or on ground ("Upcoming Routes")
 
 * **Muted airport markers** — All departure and arrival airports for upcoming bookings
-* **Dashed amber lines** — Planned routes for all upcoming flights, giving a visual overview of what's ahead
+* **Dashed amber lines** — Planned routes for all upcoming flights
 
 The map automatically transitions between these three modes as flights depart, land, and enter ground time.
 
-Position data is sourced from **FlightRadar24** via ADS-B tracking. The map uses a dark theme to match the dashboard.
-
 {% hint style="info" %}
-Flight tracking must be enabled in **Settings → Integrations** for position data to appear. See the [Integrations](../settings/integrations.md) guide for setup.
+Flight tracking must be enabled in **Settings > Integrations** for position data to appear.
 {% endhint %}
 
-### Booking Cards
+## Booking Cards
 
-All booking cards are displayed on the **right half of the screen** in a scrollable list, ordered by status:
+Below the map, booking cards are displayed in a **3-column grid** grouped by status:
 
-<!-- 📸 PLACEHOLDER: Screenshot of an In Progress booking card showing route, crew, check-in count, ETA, altitude/speed, and status badge -->
-<!-- Suggested filename: .gitbook/assets/bookings-dashboard-card-inprogress.png -->
+### Ground Time
 
-#### 🔵 In Progress
-
-Bookings with at least one flight currently boarding or airborne. Each card shows:
-
-* **Booking code** and **route string** (e.g. YBBN → YSSY)
-* **Crew assigned** and **aircraft registration**
-* **Check-in progress** (e.g. 3/4 passengers)
-* **Departure time** and **ETA** — When FlightRadar24 provides an estimated arrival time, the source is shown (e.g. "ETA FlightRadar24"). Otherwise, a calculated ETA based on departure time + flight duration is shown as "ETA (calc)". Times are displayed in the arrival airport's timezone.
-* **Live telemetry** — altitude and speed for airborne flights
-* **Status badges** per flight leg (Boarding, InProgress, Completed)
-
-<!-- 📸 PLACEHOLDER: Screenshot of a Ground Time booking card showing completed outbound leg and upcoming return leg -->
-<!-- Suggested filename: .gitbook/assets/bookings-dashboard-card-groundtime.png -->
-
-#### 🟠 Ground Time
-
-Multi-leg bookings where all current flights have landed but future legs are scheduled. For example, a return flight departing the next day. The card shows:
+Multi-leg bookings where all current flights have landed but future legs are scheduled. Shows:
 
 * "Next leg in X hours" — countdown to the next scheduled departure
 * Completed legs with actual arrival times
 * Upcoming legs with scheduled departure times
 
-The **flight map** remains visible during ground time, showing the completed leg's trail and a dashed line to the next destination — see [Flight Map](#flight-map) above.
-
-{% hint style="info" %}
-**Ground Time** is an automatic status. When a flight leg completes and the booking has future legs, the booking transitions to Ground Time. When the next leg's boarding or check-in begins, it returns to In Progress.
-{% endhint %}
-
-#### 🟡 Upcoming
+### Upcoming
 
 Confirmed bookings that haven't started yet, ordered by departure time. Shows:
 
 * Scheduled departure time and "Departs in X" countdown
 * Route, crew, aircraft, and passenger count
 
-#### ✅ Recently Completed
+### Recently Completed
 
-Bookings that finished within the **last 2 hours**, then automatically removed. Provides a brief record of today's completed operations.
+Bookings that finished within the **last 2 hours**, then automatically removed. When a completed booking has saved flight track data, the **actual flight track** is shown as a map thumbnail on the card — displaying the real path flown rather than a straight-line route.
+
+## Actual Flight Tracks
+
+When a flight completes, AeroQuote automatically fetches the complete flight track from FlightRadar24. This track data is used to:
+
+* Show the **real path flown** on recently completed booking cards (as a static map thumbnail)
+* Replace the simple departure-to-arrival line in the **bookings list** with the actual route
+* Display in the **activity modal** when an "Arrived" event is present
 
 ## Automatic Flight Tracking
 
 When flight tracking is enabled, AeroQuote automatically detects key flight events via **FlightRadar24**:
 
 * **Block off** — Detected when the aircraft begins taxiing (ground movement detected)
-* **Departure** — Detected when the aircraft becomes airborne (a dedicated departure seeker polls every 2 minutes after block off until takeoff is confirmed)
-* **ETA updates** — In-flight estimated arrival time updated at key milestones (⅓, ½, and ⅔ of the flight)
-* **Arrival** — Detected when the aircraft lands near the destination airport, or when it disappears from the live feed after the expected flight duration
+* **Departure** — Detected when the aircraft becomes airborne
+* **ETA updates** — In-flight estimated arrival time updated at key milestones
+* **Arrival** — Detected when the aircraft lands near the destination airport
 * **Block on** — Estimated after arrival
 
 Crew can always override auto-detected times via the mobile app — **crew-confirmed times always take precedence** over automated tracking.
 
-### Multi-leg sequencing
-
-For bookings with multiple flight legs, AeroQuote automatically sequences departure detection. Polling for the next leg's departure **does not begin until the preceding leg has arrived or is on blocks**. This prevents false detections when the aircraft is still airborne on an earlier leg.
-
-### Aircraft tracking identifier
-
-AeroQuote resolves which identifier to use for FlightRadar24 lookups in this order:
-
-1. **Assigned registration** — Set per flight leg (useful when a generic aircraft is assigned a specific tail number closer to departure)
-2. **Aircraft registration** — The registration from the aircraft record
-3. **Flight number** — A callsign like QF1924 (used when no registration is available)
-
-Both flight number and assigned registration can be set from the **Flight Details** panel on a booking's itinerary.
-
 ### Disabling tracking per aircraft
 
-FlightRadar24 tracking can be disabled for individual aircraft from the **Aircraft Details** page using the **FlightRadar24 Tracking** toggle. When disabled, AeroQuote will not poll FR24 for that aircraft's flights — useful for aircraft that are not visible on FlightRadar24 or where tracking is not desired.
+FlightRadar24 tracking can be disabled for individual aircraft from the **Aircraft Details** page using the **FlightRadar24 Tracking** toggle. Sample aircraft created during operator signup have tracking disabled by default to prevent unnecessary API calls.
+
+## Booking Completion Email
+
+When a booking is fully completed and all block times have been recorded (approximately 2 hours after the final flight lands), AeroQuote automatically sends a **completion summary email** to:
+
+* The **operator** — includes planned vs actual duration variance analysis per flight
+* All **assigned crew members** — flight summary without cost analysis
+
+The email includes per-flight details: block off/on times, departure/arrival times, actual duration, and a static map showing the actual flight track (when available).
 
 ## Booking Expiry
 
-Bookings that are still in **Confirmed** or **Ground Time** status 24 hours after their last flight has ended are automatically marked as **Expired**. This keeps the dashboard and mobile app uncluttered by clearing out bookings the operator forgot to close.
+Bookings that are still in **Confirmed** or **Ground Time** status 24 hours after their last flight has ended are automatically marked as **Expired**.
 
 {% hint style="info" %}
-Expired bookings are **not deleted** — they can be reverted to Confirmed at any time from the booking details page using the **Revert to Confirmed** button. Expired bookings are hidden from the mobile app and the Bookings Dashboard.
+Expired bookings are **not deleted** — they can be reverted to Confirmed at any time.
 {% endhint %}
 
 ## Auto-Refresh
 
-The dashboard automatically refreshes every **60 seconds**. There is no need to manually reload the page. All sections — summary cards, activity feed, map, and booking cards — update together.
+The dashboard automatically refreshes every **60 seconds**. The page also performs a full reload every **4 hours** for long-running stability.
 
 ## Permissions
 
-The dashboard respects existing booking permissions:
+The Bookings Dashboard and Analytics page require the **bookings.view-all** permission, which is available to:
 
-* **bookings.view** — Can see bookings they are assigned to as crew
-* **bookings.view-all** — Can see all bookings for the operator
+* **Account Administrator**
+* **Manager**
+* **Chief Pilot**
 
-<!-- 📸 PLACEHOLDER: Photo or mockup of the Bookings Dashboard displayed on a wall-mounted TV in an ops room setting -->
-<!-- Suggested filename: .gitbook/assets/bookings-dashboard-tv-mockup.png -->
-<!-- This could be a real photo or a device-frame mockup showing the dashboard on a large screen -->
+Users with only `bookings.view` (Crew role) can access the bookings list and their assigned bookings, but cannot access the dashboard or analytics.
 
 ## Tips for Ops Rooms
 
-* **Full-screen mode** — Press `F11` (Windows) or `⌘ Ctrl F` (Mac) for a true full-screen experience
+* **Full-screen mode** — Press `F11` (Windows) or `Cmd Ctrl F` (Mac) for a true full-screen experience
 * **Prevent sleep** — Configure your display to stay awake, or use a "keep awake" browser extension
 * **Multiple monitors** — Open the dashboard on a dedicated screen while using the main AeroQuote app on another
-* **Session timeout** — The page includes an auto-refresh meta tag to keep the session alive during the configured session lifetime
+* **Session timeout** — The page includes an auto-refresh meta tag to keep the session alive


### PR DESCRIPTION
Adds a new **Bookings Dashboard** page to the operator guides covering the full-screen dark-mode ops display:

## Contents

- **Opening the Dashboard** — New tab from bookings list, full-screen dark theme
- **Layout** — Header with live clock, 4 summary cards, activity feed, live flight map
- **Activity Feed** — Last 6 events (check-ins, boarding, departures, arrivals)
- **Live Flight Map** — Dark-styled Google Maps with position trails and aircraft markers
- **Booking Sections:**
  - 🔵 In Progress — active flights with telemetry (altitude, speed, ETA)
  - 🟠 Ground Time — multi-leg bookings waiting between flights
  - 🟡 Upcoming — confirmed bookings by departure time
  - ✅ Recently Completed — finished within last 2 hours
- **Ground Time status** — New booking lifecycle state for overnight/layover periods
- **Auto-refresh** (10s), permissions, ops room tips

Added to SUMMARY.md under Bookings (Operators).