### PR TITLE
Add cost management guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -55,6 +55,7 @@
   * [Add a stop between two airports](guides/quotes/add-a-stop-between-two-airports.md)
   * [Edit the Price of a Quote](guides/quotes/edit-the-price-of-a-quote.md)
   * [Require T\&Cs to be accepted online](guides/quotes/require-t-and-cs-to-be-accepted-online.md)
+  * [Cost Management](guides/quotes/cost-management.md)
   * [Quote Details Page](guides/quotes/quote-details-page/README.md)
     * [Edit Quote valid till date](guides/quotes/quote-details-page/edit-quote-valid-till-date.md)
 * [Request For Quote](guides/request-for-quote/README.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -20,6 +20,7 @@
   * [Aircraft Details](guides/aircraft/aircraft-details.md)
   * [Flight Performance](guides/aircraft/flight-performance.md)
   * [Costings](guides/aircraft/costings.md)
+    * [Cost Types](guides/aircraft/cost-types.md)
   * [Cost Simulator](guides/aircraft/cost-simulator.md)
   * [Aircraft Images](guides/aircraft/aircraft-images.md)
   * [Adding aircraft (with External Operator)](guides/aircraft/adding-aircraft-with-external-operator.md)

--- a/guides/aircraft/cost-types.md
+++ b/guides/aircraft/cost-types.md
@@ -114,14 +114,13 @@ Ground time charges appear as separate rows in the itinerary between consecutive
 
 ## Cost Rules (Flight Type Filtering)
 
-For most cost types (except Daily and Overnight), you can choose which flight types the cost applies to:
+For most cost types (except Daily, Overnight, and Ground Time), you can choose which flight types the cost applies to:
 
 | Rule | Description |
 |------|-------------|
 | **All Sectors** | Applies to both charter and ferry flights (default) |
 | **Charter Only** | Applies only to revenue/charter flights |
 | **Ferry Only** | Applies only to repositioning/ferry flights |
-| **Minimum Charge** | Sets a minimum charge regardless of distance or duration |
 
 {% hint style="success" %}
 **Example:** You might set handling fees as "All Sectors" since you pay them at every airport, but set catering charges as "Charter Only" since ferry flights carry no passengers.

--- a/guides/aircraft/cost-types.md
+++ b/guides/aircraft/cost-types.md
@@ -1,0 +1,150 @@
+---
+description: Understand each aircraft cost type available when configuring sector charges.
+---
+
+# Cost Types
+
+When adding or editing costs on the Aircraft Costings page, you choose from several cost types. Each type determines how the charge is calculated and applied to flights in your quotes and bookings.
+
+---
+
+## Per Flight Hour
+
+Charged for every hour of flight time on a sector. Use this for costs that scale with how long the aircraft is in the air.
+
+**Common uses:** engine maintenance reserves, insurance per flight hour, crew hourly costs
+
+**How it's calculated:** hourly rate × flight duration (in hours)
+
+---
+
+## Per Landing / Sector
+
+A flat charge applied once per landing or flight sector. Use this for fixed costs that occur each time the aircraft lands.
+
+**Common uses:** handling fees, landing fees, navigation charges, airport services
+
+**How it's calculated:** flat rate × number of sectors
+
+---
+
+## Per Passenger
+
+Charged per passenger on each charter sector. Use this for costs that scale with the number of passengers carried.
+
+**Common uses:** passenger facility charges, catering per head, insurance per passenger, terminal fees
+
+**How it's calculated:** per-passenger rate × number of passengers × number of charter sectors
+
+{% hint style="info" %}
+Per-passenger charges only apply to charter flights, not ferry/repositioning flights.
+{% endhint %}
+
+---
+
+## Per Distance
+
+Charged based on the distance flown. When you select Per Distance, you choose the distance unit:
+
+### Per Kilometer
+
+Rate applied per kilometer of great-circle distance between airports.
+
+### Per Nautical Mile
+
+Rate applied per nautical mile of great-circle distance between airports. This is the most common unit in aviation.
+
+### Per Mile
+
+Rate applied per statute mile of great-circle distance between airports.
+
+**Common uses:** enroute navigation charges, fuel surcharges, airway fees
+
+**How it's calculated:** distance rate × distance flown (in the selected unit)
+
+{% hint style="info" %}
+Distance is calculated as the great-circle distance between the departure and arrival airports for each sector.
+{% endhint %}
+
+---
+
+## Daily Charge
+
+A flat charge applied for each calendar day of the trip. Use this for costs that accrue on a per-day basis regardless of flying activity.
+
+**Common uses:** crew per diem, aircraft daily insurance, daily parking/hangarage
+
+**How it's calculated:** daily rate × number of trip days
+
+{% hint style="info" %}
+Daily charges are applied at the option level, not per individual flight. The number of days is calculated from the first departure to the last arrival.
+{% endhint %}
+
+---
+
+## Overnight Charge
+
+A flat charge for each night the aircraft stays away from its homebase. Use this for costs related to overnight accommodation or away-from-base operations.
+
+**Common uses:** crew accommodation, overnight parking, overnight hangarage, security
+
+**How it's calculated:** overnight rate × number of nights away
+
+{% hint style="info" %}
+Like daily charges, overnight charges are applied at the option level. A night is counted when the aircraft is away from its homebase overnight.
+{% endhint %}
+
+---
+
+## Ground Time
+
+Charged per hour that the aircraft is on the ground between flights. Use this when you want to recover costs for the aircraft waiting between sectors.
+
+**Common uses:** aircraft standby charges, ground handling during turnarounds, opportunity cost
+
+**How it's calculated:** hourly rate × ground time (in hours) between consecutive flights
+
+You can optionally set a **maximum charge** to cap the ground time cost. This is useful when you want to charge for short waits but not penalise long overnight stops.
+
+{% hint style="info" %}
+Ground time charges appear as separate rows in the itinerary between consecutive flights, making them easy to identify and adjust.
+{% endhint %}
+
+---
+
+## Cost Rules (Flight Type Filtering)
+
+For most cost types (except Daily and Overnight), you can choose which flight types the cost applies to:
+
+| Rule | Description |
+|------|-------------|
+| **All Sectors** | Applies to both charter and ferry flights (default) |
+| **Charter Only** | Applies only to revenue/charter flights |
+| **Ferry Only** | Applies only to repositioning/ferry flights |
+| **Minimum Charge** | Sets a minimum charge regardless of distance or duration |
+
+{% hint style="success" %}
+**Example:** You might set handling fees as "All Sectors" since you pay them at every airport, but set catering charges as "Charter Only" since ferry flights carry no passengers.
+{% endhint %}
+
+---
+
+## Setting Up Costs
+
+To add or edit aircraft costs:
+
+1. Go to **Aircraft** from the sidebar
+2. Click on an aircraft and navigate to the **Costings** tab
+3. Scroll to **Aircraft costs that you will pay**
+4. Click **Add new** to add a cost, or click the pencil icon to edit an existing one
+5. The wizard guides you through: **Cost Type → Cost Rules → Amount → Name**
+
+The cost name is auto-generated from your selections but can be customised.
+
+---
+
+## Next Steps
+
+- [Costings](costings.md) — Configure pricing models and rates
+- [Cost Simulator](cost-simulator.md) — Test how your costs affect quotes
+- [Cost Management](../quotes/cost-management.md) — Manage costs on individual quotes

--- a/guides/aircraft/costings.md
+++ b/guides/aircraft/costings.md
@@ -70,16 +70,15 @@ Protect your margins with minimums:
 
 ---
 
-## Additional Charges
+## Sector Charges (Cost Types)
 
-Configure extra costs that may apply:
+Add recurring costs that are automatically calculated on every quote for this aircraft. These are configured in the **Aircraft costs that you will pay** section.
 
-| Charge | Description |
-|--------|-------------|
-| **Overnight Fee** | When aircraft stays away from homebase |
-| **Crew Expenses** | Per diem for crew on overnight trips |
-| **International Fee** | Additional charge for international flights |
-| **Weekend/Holiday Rate** | Premium for off-hours operations |
+Each cost has a **type** that determines how it's calculated (per hour, per sector, per passenger, per distance, daily, overnight, or ground time) and a **rule** that controls which flights it applies to (all sectors, charter only, or ferry only).
+
+{% hint style="info" %}
+See [Cost Types](cost-types.md) for a detailed explanation of each cost type, how it's calculated, and when to use it.
+{% endhint %}
 
 ---
 
@@ -120,5 +119,6 @@ For a typical quote, AeroQuote calculates:
 
 ## Next Steps
 
+- [Cost Types](cost-types.md) — Detailed guide to each cost type and when to use it
 - [Cost Simulator](cost-simulator.md) — Test your pricing configuration
 - [Flight Performance](flight-performance.md) — Verify performance data

--- a/guides/aircraft/costings.md
+++ b/guides/aircraft/costings.md
@@ -82,6 +82,26 @@ See [Cost Types](cost-types.md) for a detailed explanation of each cost type, ho
 
 ---
 
+## Minimum Customer Price
+
+Set a **floor price** for this aircraft to ensure quotes never fall below a minimum amount, regardless of how the price is calculated.
+
+| Field | Description |
+|-------|-------------|
+| **Minimum Customer Price** | The lowest price that will be quoted for this aircraft |
+
+When a quote is generated and the calculated price (whether from hourly rates or margin-based pricing) is below the minimum, the quoted price is automatically raised to the minimum amount.
+
+{% hint style="info" %}
+Leave this field empty to disable the minimum. A value of zero is treated as "not set".
+{% endhint %}
+
+{% hint style="success" %}
+**Use this for short flights** — If your shortest possible flight still costs a minimum amount to operate (crew callout, fuel, handling), set a minimum customer price to ensure you don't quote below your break-even.
+{% endhint %}
+
+---
+
 ## Currency
 
 Set the currency for this aircraft's pricing:

--- a/guides/quotes/cost-management.md
+++ b/guides/quotes/cost-management.md
@@ -1,0 +1,152 @@
+---
+description: View, edit, and manage individual cost line items on your quotes.
+---
+
+# Cost Management
+
+AeroQuote now gives you full visibility and control over every cost that makes up a quote. Each flight, ground time, and option displays an itemised cost breakdown that you can expand, edit, and customise.
+
+---
+
+## What's New
+
+Previously, flight costs were summarised as a single total. With this update:
+
+- Every cost is displayed as its own **line item** (flight costs, landing charges, parking charges, fuel uplifts, and more)
+- You can **add custom costs** to any flight or option
+- You can **toggle individual costs** on or off without deleting them
+- You can **edit amounts** on any cost item
+- **Ground time charges** now appear as a separate row between flights in the itinerary
+- Cost breakdowns carry through from **quotes to bookings** automatically
+
+---
+
+## Viewing Cost Breakdowns
+
+### On a Flight Item
+
+Each flight item in your quote now has an expandable cost section.
+
+1. Open a quote and navigate to the **Options** tab
+2. Find a flight item card
+3. Click the cost summary bar (e.g. "3 costs — $1,250") to expand
+
+When expanded, you'll see each cost line item:
+
+| Column | Description |
+|--------|-------------|
+| **Name** | The cost type (e.g. "Flight Costs", "Landing Charges") |
+| **Amount** | The cost in your operator currency |
+| **Toggle** | Include or exclude this cost from the total |
+
+### On an Option
+
+Option-level costs (day charges, overnight charges, and custom charges) appear in a separate cost section below the flight items within the option.
+
+---
+
+## Adding a Custom Cost
+
+You can add your own cost items to any flight or option:
+
+1. Expand the cost breakdown on a flight item or option
+2. Click **Add Cost**
+3. Enter:
+   - **Name** — A description (e.g. "Handling Fee", "De-icing")
+   - **Amount** — The cost in cents
+4. Click **Save**
+
+The new cost is immediately included in the flight and option totals.
+
+{% hint style="info" %}
+Custom costs you add are marked differently from system-generated costs. You can edit or delete custom costs at any time. System-generated costs can be toggled off but not deleted.
+{% endhint %}
+
+---
+
+## Editing a Cost Amount
+
+1. Expand the cost breakdown
+2. Click the amount field on any cost item
+3. Enter the new amount
+4. The total recalculates automatically
+
+{% hint style="warning" %}
+Editing a system-generated cost (like landing charges) will override the calculated value. If you recalculate the flight, the system value will be restored.
+{% endhint %}
+
+---
+
+## Toggling Costs On or Off
+
+Each cost item has a toggle to include or exclude it from the total:
+
+1. Expand the cost breakdown
+2. Click the toggle next to any cost item
+3. The flight and option totals update immediately
+
+This is useful when you want to:
+- Temporarily exclude a cost for a special quote
+- See the impact of individual costs on the total
+- Keep a cost on record without including it in the price
+
+---
+
+## Ground Time Charges
+
+Ground time charges represent the cost of the aircraft waiting on the ground between flights. These appear as separate rows in the itinerary between consecutive flights.
+
+### How Ground Time is Calculated
+
+1. AeroQuote calculates the time gap between one flight's arrival and the next flight's departure
+2. The ground time hourly rate is looked up from the aircraft's sector charges
+3. The charge is calculated: **hourly rate x (ground time minutes / 60)**
+
+### Setting Up Ground Time Rates
+
+To configure ground time charging for an aircraft:
+
+1. Go to **Aircraft** from the sidebar
+2. Click on an aircraft
+3. Navigate to the **Costings** tab
+4. Add a **Ground Time** sector charge with an hourly rate
+
+{% hint style="info" %}
+If no ground time rate is configured for an aircraft, no ground time charges will appear.
+{% endhint %}
+
+---
+
+## Cost Summary View (Operators)
+
+The **Summary** step of the quote builder shows a complete cost breakdown for each option:
+
+- Option-level costs (day charges, overnight charges, custom charges)
+- Per-flight cost breakdowns with all line items
+- Ground time charges between flights
+- Total cost per option
+
+This gives you a clear picture of where costs come from before setting your price.
+
+---
+
+## Costs in Bookings
+
+When a quote is converted to a booking, all cost items are automatically copied:
+
+- Flight cost items carry over to the booking flight items
+- The same cost breakdown is available on the booking side
+- You can view costs on the booking for reference
+
+---
+
+## Tips
+
+{% hint style="success" %}
+**Use the cost breakdown to verify quotes** — Before sending a quote to a customer, expand the costs on each flight to make sure landing charges, fuel, and other costs look correct.
+{% endhint %}
+
+- Add custom costs for items not automatically calculated (handling fees, permits, catering)
+- Toggle off costs you've negotiated away rather than deleting them — you'll have a record if you need to add them back
+- Check ground time charges on multi-leg trips to make sure the wait time costs are reasonable
+- The option total always reflects only the costs that are toggled "on"

--- a/guides/quotes/cost-management.md
+++ b/guides/quotes/cost-management.md
@@ -17,6 +17,7 @@ Previously, flight costs were summarised as a single total. With this update:
 - You can **add custom costs** to any flight or option
 - You can **toggle individual costs** on or off without deleting them
 - You can **edit amounts** on any cost item
+- You can **control customer visibility** — choose exactly which costs appear on customer quotes and PDFs
 - You can **remove ferry flights** from estimates
 - **Per-passenger charges** are now shown as a separate line item
 - **Ground time charges** now appear as a separate row between flights in the itinerary
@@ -152,6 +153,36 @@ This is useful when you want to:
 - Temporarily exclude a cost for a special quote
 - See the impact of individual costs on the total
 - Keep a cost on record without including it in the price
+
+---
+
+## Customer Visibility
+
+You can control which cost items are visible to your customers on their quote page and PDF. By default, all costs are **hidden** from customers — the customer sees only the total price.
+
+### Toggling Customer Visibility
+
+1. Expand the cost breakdown on a flight item
+2. Hover over a cost item to reveal the **eye icon**
+3. Click the eye icon to toggle visibility:
+   - **Blue eye** — visible to the customer (icon stays visible persistently)
+   - **Grey eye-slash** — hidden from the customer (icon appears on hover only)
+
+### What the Customer Sees
+
+When one or more cost items are marked as visible, an expandable **Operating Costs** section appears on the customer's quote page. This section shows only the costs you've chosen to share — along with the cost name, amount, and any explanatory notes.
+
+{% hint style="info" %}
+Customer visibility only controls what is **displayed** to the customer. Hidden costs are still included in the total price — they are not excluded from pricing.
+{% endhint %}
+
+{% hint style="success" %}
+**Use visibility strategically** — Share costs like landing charges or fuel uplift to justify your pricing, while keeping internal costs like maintenance reserves private.
+{% endhint %}
+
+### Visibility on PDFs
+
+The same visibility rules apply to quote PDFs. Only cost items marked as visible will appear on the generated PDF, regardless of which PDF variant your operator uses.
 
 ---
 

--- a/guides/quotes/cost-management.md
+++ b/guides/quotes/cost-management.md
@@ -21,6 +21,7 @@ Previously, flight costs were summarised as a single total. With this update:
 - **Per-passenger charges** are now shown as a separate line item
 - **Ground time charges** now appear as a separate row between flights in the itinerary
 - Cost breakdowns carry through from **estimates to quotes to bookings** automatically
+- **Automatic price updates** — for aircraft using margin-based pricing, the option price recalculates automatically when you change costs
 
 ---
 
@@ -54,7 +55,7 @@ You can edit, add, toggle, and delete costs before generating a quote:
 - **Toggle**: Click the check/minus icon to include or exclude a cost
 - **Delete**: Click the trash icon on custom (non-system) cost items
 
-All changes update the aircraft option's total cost in real time. When you generate a quote, your edited costs carry through to the quote's cost items.
+All changes update the aircraft option's total cost in real time. If the aircraft uses margin-based pricing, the option price is also recalculated automatically and you'll see a notification showing the old and new price. When you generate a quote, your edited costs carry through to the quote's cost items.
 
 {% hint style="info" %}
 If you change the charter flights (add, remove, or modify a route), the estimates recalculate from scratch and any cost edits will be reset.
@@ -133,6 +134,10 @@ Custom costs you add are marked differently from system-generated costs. You can
 Editing a system-generated cost (like landing charges) will override the calculated value. If you recalculate the flight, the system value will be restored.
 {% endhint %}
 
+{% hint style="info" %}
+For margin-based aircraft, the option price will automatically update to reflect the new cost. You'll see a notification with the old and new price.
+{% endhint %}
+
 ---
 
 ## Toggling Costs On or Off
@@ -147,6 +152,29 @@ This is useful when you want to:
 - Temporarily exclude a cost for a special quote
 - See the impact of individual costs on the total
 - Keep a cost on record without including it in the price
+
+---
+
+## Automatic Price Recalculation
+
+When you edit costs on a quote option that uses a **margin-based** aircraft, AeroQuote automatically recalculates the option price using the aircraft's configured margin percentage.
+
+### How It Works
+
+1. You add, edit, toggle, or delete a cost item on a flight or option
+2. The option's total cost updates
+3. If the aircraft has a **price margin** configured (not hourly rates), the price recalculates: **price = cost + (cost × margin%)**
+4. A notification appears showing the previous price and the new price
+
+### When It Doesn't Apply
+
+- **Hourly-rate aircraft** — Price is based on flight duration, not costs, so it doesn't change when costs are edited
+- **Cost overridden** — If you've manually overridden the option cost, neither cost nor price will auto-recalculate
+- **Manual price edits** — Only automatic cost changes trigger recalculation; editing the price directly in the option modal works as before
+
+{% hint style="info" %}
+The margin percentage used comes from the aircraft's pricing configuration. To change it, go to **Aircraft → Costings** and update the price margin.
+{% endhint %}
 
 ---
 

--- a/guides/quotes/cost-management.md
+++ b/guides/quotes/cost-management.md
@@ -1,10 +1,10 @@
 ---
-description: View, edit, and manage individual cost line items on your quotes.
+description: View, edit, and manage individual cost line items on your quotes and estimates.
 ---
 
 # Cost Management
 
-AeroQuote now gives you full visibility and control over every cost that makes up a quote. Each flight, ground time, and option displays an itemised cost breakdown that you can expand, edit, and customise.
+AeroQuote now gives you full visibility and control over every cost that makes up a quote. Each flight, ground time, and option displays an itemised cost breakdown that you can expand, edit, and customise — starting from the estimate stage, before a quote is even created.
 
 ---
 
@@ -12,16 +12,74 @@ AeroQuote now gives you full visibility and control over every cost that makes u
 
 Previously, flight costs were summarised as a single total. With this update:
 
-- Every cost is displayed as its own **line item** (flight costs, landing charges, parking charges, fuel uplifts, and more)
+- Every cost is displayed as its own **line item** (flight costs, landing charges, parking charges, fuel uplifts, per-passenger charges, and more)
+- Cost breakdowns are available at the **estimate stage** — before a quote is created
 - You can **add custom costs** to any flight or option
 - You can **toggle individual costs** on or off without deleting them
 - You can **edit amounts** on any cost item
+- You can **remove ferry flights** from estimates
+- **Per-passenger charges** are now shown as a separate line item
 - **Ground time charges** now appear as a separate row between flights in the itinerary
-- Cost breakdowns carry through from **quotes to bookings** automatically
+- Cost breakdowns carry through from **estimates to quotes to bookings** automatically
 
 ---
 
-## Viewing Cost Breakdowns
+## Estimate-Stage Cost Breakdown
+
+Cost breakdowns are now visible at the estimate stage — on both the **Requests** page and the **Quote Builder** — before a quote is created.
+
+### Viewing Flight Costs on Estimates
+
+When you calculate estimates for a request, each aircraft option shows all charter and ferry flights with an expandable cost breakdown:
+
+1. Go to **Requests** and open a request
+2. Add your flight details and let the estimates calculate
+3. Under each aircraft, click the flight summary row (e.g. "3 flights — $33,459 total cost") to expand
+4. Each flight is listed with its type (Charter or Ferry), route, departure time, and duration
+5. Click the cost summary bar on any flight (e.g. "2 costs — $4,343") to expand individual cost items
+
+Each cost item shows:
+- A colour-coded **type badge** (Flight Cost, Landing Charge, Parking Charge, Per Passenger Charge, etc.)
+- The cost **name** and **amount**
+- A **toggle** to include or exclude the cost from the total
+
+Option-level charges (day charges, overnight charges) appear in a separate section below the flights.
+
+### Editing Costs at the Estimate Stage
+
+You can edit, add, toggle, and delete costs before generating a quote:
+
+- **Edit**: Click the pencil icon on any cost item to change its name or amount
+- **Add**: Click **Add cost** to create a custom cost item on any flight
+- **Toggle**: Click the check/minus icon to include or exclude a cost
+- **Delete**: Click the trash icon on custom (non-system) cost items
+
+All changes update the aircraft option's total cost in real time. When you generate a quote, your edited costs carry through to the quote's cost items.
+
+{% hint style="info" %}
+If you change the charter flights (add, remove, or modify a route), the estimates recalculate from scratch and any cost edits will be reset.
+{% endhint %}
+
+### Removing Ferry Flights
+
+The estimator automatically adds ferry flights when an aircraft needs to reposition (e.g. fly from its homebase to the charter departure point). You can remove unwanted ferry flights:
+
+1. Expand the flights under an aircraft option
+2. Find a ferry flight (marked with an amber **Ferry** badge)
+3. Click the **X** button on the right side of the ferry flight row
+4. The ferry flight is removed and all totals (cost and ferry time) update immediately
+
+{% hint style="warning" %}
+Removed ferry flights will reappear if the estimates are recalculated (e.g. when you add or change a charter flight), since the flight plan has changed.
+{% endhint %}
+
+### Per-Passenger Charges
+
+If an aircraft has per-passenger sector charges configured, these now appear as a separate **Per Passenger Charge** line item on each charter flight, rather than being hidden inside the flight cost total. This makes it easy to see and adjust passenger-related costs independently.
+
+---
+
+## Viewing Cost Breakdowns on Quotes
 
 ### On a Flight Item
 


### PR DESCRIPTION
## Summary
- Adds a new **Cost Management** guide under Quotes documenting the new itemised cost breakdown feature
- Covers viewing/expanding cost breakdowns, adding custom costs, toggling costs, ground time charges, and cost items in bookings
- Adds the new page to the navigation in SUMMARY.md

## Test plan
- [ ] Verify the new page renders correctly in GitBook
- [ ] Check all sections are clear and match the current UI
- [ ] Verify SUMMARY.md navigation entry appears under Quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)