### PR TITLE
Add Quote Builder step-by-step guide

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -52,6 +52,7 @@
   * [Creating a Request (Operators)](guides/requests/creating-a-request-operators.md)
   * [Creating a Request (Brokers)](guides/requests/creating-a-request-brokers.md)
 * [Quotes](guides/quotes/README.md)
+  * [Creating a Quote](guides/quotes/creating-a-quote.md)
   * [Create a Quote from a Request (Operators)](guides/quotes/create-a-quote-from-a-request-operators.md)
   * [Create a Quote from a Request (Brokers)](guides/quotes/create-a-quote-from-a-request-brokers.md)
   * [Add a stop between two airports](guides/quotes/add-a-stop-between-two-airports.md)

--- a/guides/quotes/README.md
+++ b/guides/quotes/README.md
@@ -9,9 +9,11 @@ coverY: 435
 
 Quotes are the second step of a [customer flow](../../getting-started/concepts.md#customer-flow).  Quotes are the central piece of the AeroQuote system and are where you will spend most of your effort learning and customizing.
 
-To get started, learn how to quickly create a quote from a [Request](../requests/).  It's the fastest and easiest way.
+To get started, learn how to create a quote using the Quote Builder — or create one quickly from a [Request](../requests/).
 
-Below are two guides to get you started, one for Operator subscriptions and another for Brokers.
+{% content-ref url="creating-a-quote.md" %}
+[creating-a-quote.md](creating-a-quote.md)
+{% endcontent-ref %}
 
 {% content-ref url="create-a-quote-from-a-request-operators.md" %}
 [create-a-quote-from-a-request-operators.md](create-a-quote-from-a-request-operators.md)

--- a/guides/quotes/create-a-quote-from-a-request-operators.md
+++ b/guides/quotes/create-a-quote-from-a-request-operators.md
@@ -4,7 +4,7 @@ description: Operator edition
 
 # Create a Quote from a Request (Operators)
 
-Creating Quotes from Requests is the fastest and easiest way to build your quote.  Watch the training video below (which also contains all the steps to create a Request) till the end to see how.
+Creating Quotes from Requests is the fastest way to build your quote — the flight details are pre-filled from the Request.
 
 {% embed url="https://vimeo.com/825790504" %}
 Create a Request training video
@@ -12,6 +12,15 @@ Create a Request training video
 
 ### Steps to create a Quote from a Request
 
-1. Create or edit an existing [Request](../requests/creating-a-request-operators.md).
+1. Create or edit an existing [Request](../requests/creating-a-request-operators.md)
 2. Click on the aircraft you wish to include in your quote
-3. Click Generate Quote
+3. Click **Generate Quote**
+4. The [Quote Builder](creating-a-quote.md) opens with the Request's flight details pre-filled
+5. Review and adjust the details — dates, aircraft selection, and passenger count may need updating
+6. Follow the builder steps through to **Create Quote**
+
+Your new quote opens automatically on the quote detail page.
+
+{% hint style="info" %}
+You can also create quotes from scratch (without a Request) using the **Create Quote** button on the Quotes page. See [Creating a Quote](creating-a-quote.md) for the full step-by-step guide.
+{% endhint %}

--- a/guides/quotes/creating-a-quote.md
+++ b/guides/quotes/creating-a-quote.md
@@ -1,0 +1,194 @@
+---
+description: Step-by-step guide to creating a quote using the Quote Builder.
+---
+
+# Creating a Quote
+
+The Quote Builder walks you through creating a quote in four steps — from selecting a customer through to choosing aircraft and reviewing pricing. You can also create quotes directly from a Request, which pre-fills the flight details.
+
+---
+
+## Opening the Quote Builder
+
+There are two ways to start:
+
+- **From the Quotes page** — Click the **Create Quote** button in the top right
+- **From a Request** — Select one or more aircraft on a Request and click **Generate Quote** (flight details will be pre-filled)
+
+---
+
+## Step 1: Quote Details
+
+Set the customer and basic quote information.
+
+### Contact
+
+Search for an existing contact by name or email. Start typing and select from the dropdown.
+
+{% hint style="info" %}
+If the contact doesn't exist yet, you can create one inline without leaving the builder.
+{% endhint %}
+
+### Job Notes (optional)
+
+Internal notes for your team. Use these for special instructions, coordination details, or context about the enquiry. These notes are not visible to the customer.
+
+### Total Passengers
+
+Enter the expected number of passengers. This is used to check aircraft capacity — the builder will flag any aircraft that can't accommodate this number.
+
+### Terms & Conditions Template (optional)
+
+Select a T&C template from your saved templates. If left blank, your operator's default template is used. These terms are displayed to the customer when they view the quote online.
+
+Click **Next** to continue.
+
+---
+
+## Step 2: Flights
+
+Build the flight itinerary by adding one or more flight legs.
+
+### Adding a Flight
+
+For each flight leg, enter:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| **Departure airport** | Yes | Search by airport name, city, or ICAO/IATA code |
+| **Arrival airport** | Yes | Search by airport name, city, or ICAO/IATA code |
+| **Departure date & time** | Yes | Date and time in the departure airport's timezone |
+
+When you select an airport, the departure time defaults to 8:00 AM the next day in that airport's local timezone.
+
+### Selecting an FBO
+
+If an airport has FBO facilities on file, a facility selector appears after selecting the airport. Choose the appropriate FBO for departure or arrival — this information appears on the quote sent to the customer.
+
+### Route Library
+
+Click **Load Route** to search your saved routes. Selecting a route auto-fills the departure and arrival airports, saving time on frequently quoted routes.
+
+### Custom Airports
+
+If an airport isn't in the database, you can create it inline from the search dropdown. The new airport is saved for future use.
+
+### Multi-Leg Itineraries
+
+- **Add Flight** — Adds a new flight leg after the current one
+- **Add Return Flight** — Creates a return leg with the departure and arrival airports swapped
+- **Delete** — Removes a flight leg
+- **Drag to reorder** — Rearrange flight legs by dragging them into the correct order
+
+The interactive map updates as you add flights, showing your complete route.
+
+{% hint style="info" %}
+**Return to homebase** — Check this box on a flight to automatically include a ferry positioning flight back to the aircraft's homebase in the pricing calculation.
+{% endhint %}
+
+Click **Next** to continue.
+
+---
+
+## Step 3: Aircraft
+
+Select one or more aircraft to include as options on the quote. Each selected aircraft becomes a separate option for the customer to choose from.
+
+### Available Aircraft
+
+The builder calculates pricing for every aircraft in your fleet based on the flights you entered:
+
+| Column | Description |
+|--------|-------------|
+| **Aircraft** | Registration, type, and image |
+| **Customer Price** | Estimated price to the customer |
+| **Cost to You** | Your estimated operating cost |
+| **Charter Time** | Total flying time for charter legs |
+| **Ferry Time** | Positioning time to/from homebase |
+
+Click an aircraft to select it. You can select multiple aircraft — each becomes a separate option on the quote.
+
+### Search and Filter
+
+Use the search box to filter aircraft by registration, name, or external operator.
+
+### Availability and Operational Cautions
+
+The builder checks for potential issues and displays caution badges next to each aircraft:
+
+**Availability cautions:**
+- **Red** — Aircraft is already scheduled in an accepted quote during the requested period
+- **Amber** — Aircraft is booked in a confirmed booking during the requested period
+- **Green** — No scheduling conflicts
+
+**Operational cautions:**
+- **Red** — Aircraft cannot complete the mission (runway too short, passenger count exceeds capacity)
+- **Amber** — Flight distance may exceed aircraft range
+- **Green** — No operational issues
+
+{% hint style="warning" %}
+Review caution indicators before proceeding. Click on a caution to see the specific details.
+{% endhint %}
+
+### Cost Breakdown
+
+Expand any aircraft option to see the full cost breakdown per flight leg:
+
+- **Flight costs** — Fuel, hourly rate, sector charges
+- **Landing and handling** — Airport-specific fees
+- **Parking and overnight** — Ground time charges for multi-day trips
+- **Ferry flights** — Positioning costs (shown separately from charter legs)
+
+You can edit individual cost items — toggle costs on or off, change amounts, or add new line items. This is useful for adjusting estimates before creating the quote.
+
+### External Aircraft and RFQ
+
+If you have aircraft from external operators in your fleet, you can toggle **RFQ** (Request for Quote) per aircraft. This flags the option to send an RFQ to the external operator after the quote is created.
+
+Click **Next** to continue.
+
+---
+
+## Step 4: Quote Summary
+
+Review all the details before creating the quote:
+
+- **Contact** — Name, email, and phone
+- **Aircraft options** — Each selected aircraft with:
+  - Total customer price and operator cost
+  - Flight details table with departure/arrival times in both local and Zulu (UTC)
+  - Flight type (Charter or Ferry) and duration per leg
+
+{% hint style="success" %}
+Use the step indicators at the top to jump back to any previous step if you need to make changes.
+{% endhint %}
+
+Click **Create Quote** to finalise. AeroQuote creates the quote with all selected aircraft as options, assigns the contact, and opens the new quote's detail page.
+
+---
+
+## After Creating a Quote
+
+The quote is created in **Draft** status. From the quote detail page you can:
+
+- Edit pricing, add or remove options, and adjust cost line items — see [Edit the Price of a Quote](edit-the-price-of-a-quote.md)
+- Manage individual cost items — see [Cost Management](cost-management.md)
+- Send the quote to the customer with your document template attached
+- Set a quote validity date — see [Edit Quote Valid Till Date](quote-details-page/edit-quote-valid-till-date.md)
+- Require T&C acceptance online — see [Require T&Cs to be Accepted Online](require-t-and-cs-to-be-accepted-online.md)
+
+Once the customer accepts, you can [convert the quote to a booking](../bookings-operators/create-a-booking-from-a-quote.md).
+
+---
+
+## Tips
+
+{% hint style="info" %}
+**Creating from a Request?** The builder pre-fills flights and may pre-select aircraft from the Request. Review and adjust as needed — this is the fastest way to generate quotes.
+{% endhint %}
+
+- Complete the Flights step accurately — aircraft pricing, ferry times, and cautions are all calculated from these details
+- Use the Route Library for repeat routes to save time and ensure consistency
+- Select multiple aircraft to give your customer options — each becomes a separate option they can compare
+- Check caution badges before finalising — availability conflicts and operational issues are easier to resolve before sending the quote
+- Use the cost breakdown editor to fine-tune estimates on the Aircraft step rather than editing after creation

--- a/guides/requests/creating-a-request-operators.md
+++ b/guides/requests/creating-a-request-operators.md
@@ -1,22 +1,204 @@
 ---
-description: Operator edition
+description: Step-by-step guide to creating a Request for Operators.
 ---
 
 # Creating a Request (Operators)
 
-Requests form the first step of a job flow.  Use Requests to record inbound charter requests and provide charter price estimates back to customers in record time.  Looking for the Broker edition? [find it here](creating-a-request-brokers.md).
+Requests are the first step in your quoting workflow. Use them to record inbound charter enquiries, get instant price estimates across your fleet, and generate quotes with a single click.
 
 {% embed url="https://vimeo.com/825790504" %}
 Create a Request training video
 {% endembed %}
 
-### Steps to create a Request (Operator)
+---
 
-1. Click on Requests in the nav bar
-2. Click on Add new Request
-3. Add notes and passenger count
-4. Select a contact or add a new contact
-5. Add one or more Charter flight legs (AeroQuote will automatically add ferry legs)
-6. Review the estimates and any cautions
-7. Click on the aircraft you wish to include in your quote
-8. Click Save Request or Generate Quote.
+## Opening a New Request
+
+1. Click **Requests** in the sidebar
+2. Click **Add new Request**
+
+The Request page opens as a single workspace — details, flights, and aircraft estimates are all visible on one screen.
+
+---
+
+## Request Details
+
+The top-left section captures the basic enquiry information:
+
+### Status
+
+Set the request status:
+
+| Status | Meaning |
+|--------|---------|
+| **Active** | Currently being worked on |
+| **Not Interested** | Customer declined or not proceeding |
+| **Call Back** | Follow up required |
+
+Once a quote has been generated from the request, the status shows **Quote Already Created** with a link to the quote.
+
+### Total Passengers
+
+Enter the expected number of passengers. This is used to:
+- Check aircraft capacity — the estimates table flags aircraft that can't accommodate this number
+- Calculate weight-related costs
+
+### Contact
+
+Search for an existing contact by name or email. If the contact doesn't exist, you can create one inline without leaving the page.
+
+The contact carries through when you generate a quote — they become the main contact on the quote.
+
+### Job Notes
+
+Internal notes for your team. These notes carry through to the quote when generated.
+
+### Terms & Conditions Template
+
+Select a T&C template from your saved templates, or leave as **Use Default Template**. This determines which terms are shown to the customer on the online quote view.
+
+---
+
+## Interactive Map
+
+The right side of the details section shows an interactive map that updates in real time as you add flights. It displays your complete route with all departure and arrival points.
+
+---
+
+## Flights
+
+The flights section sits below the details area. Add one or more charter flight legs to define the itinerary.
+
+### Adding a Flight
+
+For each flight leg, enter:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| **Departure Location** | Yes | Search by airport name, city, or ICAO/IATA code |
+| **Arrival Location** | Yes | Search by airport name, city, or ICAO/IATA code |
+| **Departing At** | Yes | Date and time in the departure airport's timezone |
+
+When you select a departure airport, the time defaults to 8:00 AM the next day in that airport's local timezone.
+
+### Selecting an FBO
+
+If an airport has FBO facilities on file, a **Choose Facility** link appears below the airport field. Click it to open a facility picker showing available FBOs with images and map locations.
+
+If an FBO is already selected, its name appears with an **FBO** badge — click to change it.
+
+### Route Library
+
+Click **Load Route** to search your saved routes by name. Selecting a route auto-fills the departure and arrival airports. The route displays as a read-only field showing the route name and ICAO codes.
+
+### Custom Airports
+
+If an airport isn't in the database, type its name and select the option to create a custom airport. The new airport is saved for future use.
+
+### Multi-Leg Itineraries
+
+- **Add Flight** — Adds a new flight leg after the current one
+- **Add Return Flight** — Creates a return leg with the departure and arrival airports swapped
+- **Load Route** — Search and load a pre-saved route
+- **Delete** — Remove a flight leg (click the trash icon)
+- **Drag to reorder** — Rearrange flight legs by dragging
+
+---
+
+## Aircraft Estimates
+
+Once all flights have departure and arrival locations, AeroQuote automatically calculates price estimates for every active aircraft in your fleet. The estimates table shows:
+
+| Column | Description |
+|--------|-------------|
+| **Aircraft** | Image, registration, and type. Click to select. |
+| **Cautions** | Availability and operational warnings (see below) |
+| **Customer Price** | Estimated charter price |
+| **Charter Time** | Total flying time for charter legs |
+| **Ferry Time** | Positioning time to/from homebase |
+| **Flights** | Number of flight legs |
+
+{% hint style="info" %}
+**Estimates recalculate automatically** whenever you change a flight, add a leg, or update the passenger count. There's no need to manually trigger a recalculation.
+{% endhint %}
+
+### Selecting Aircraft
+
+Click an aircraft image to select it — a checkmark overlay appears. You can select multiple aircraft. Selected aircraft become options on the quote when you click **Generate Quote**.
+
+### Availability and Operational Cautions
+
+Each aircraft shows caution badges:
+
+**Availability cautions:**
+- **Red** — Aircraft is already scheduled in an accepted quote during this period
+- **Amber** — Aircraft is booked in a confirmed booking during this period
+- **Green** — No scheduling conflicts
+
+**Operational cautions:**
+- **Red** — Aircraft cannot complete the mission (runway too short, passenger count exceeds capacity)
+- **Amber** — Flight distance may exceed aircraft range
+- **Green** — No operational issues
+
+Click a caution badge to see the specific details.
+
+### Expandable Flight Details
+
+Click the flights count row to expand the cost breakdown for each aircraft. This shows:
+
+- Each flight leg (Charter or Ferry) with departure and arrival airports
+- Duration per leg
+- Total cost breakdown
+- Individual cost line items that can be toggled on/off, edited, or added to
+
+### External Aircraft
+
+If your fleet includes aircraft from external operators, they appear in the table with an external operator badge. You can toggle **Create RFQ** per external aircraft to send a Request for Quote to the external operator.
+
+---
+
+## Saving and Generating
+
+Floating action buttons appear in the bottom-right corner:
+
+### Save Request
+
+Click **Save Request** to save the current state of the request — flights, aircraft selections, notes, and contact. You can return to it later and continue working.
+
+### Generate Quote
+
+Once you've selected at least one aircraft, click **Generate Quote** to create a formal quote. This:
+
+1. Creates a new quote with the contact, flights, and notes from the request
+2. Adds each selected aircraft as a separate option on the quote
+3. Carries over all cost estimates and flight details
+4. Opens the new quote's detail page automatically
+5. Updates the request status to **Quote Already Created**
+
+{% hint style="success" %}
+**Generating a quote doesn't delete the request.** The request remains linked to the quote — you can always navigate back to it from the quote.
+{% endhint %}
+
+### Send Emails and Edit Quote
+
+If you've selected external aircraft with RFQ enabled, an additional option appears to **Send Emails and Edit Quote**. This sends Request for Quote emails to external operators and generates the quote in one step. You can review and edit the notes that will be included in the emails before sending.
+
+---
+
+## Duplicating a Request
+
+You can create a new request based on an existing one. This copies the flights, notes, and passenger count — useful for repeat enquiries or similar routes.
+
+---
+
+## Tips
+
+{% hint style="info" %}
+**Requests are for speed.** Unlike the Quote Builder (which walks through steps), the Request page shows everything at once so you can get estimates in seconds. Use Requests for initial pricing, then generate a quote when you're ready to send to the customer.
+{% endhint %}
+
+- Enter flights first — aircraft estimates calculate automatically once departure and arrival airports are set
+- Use the Route Library for repeat routes to save time
+- Check caution badges before selecting aircraft — resolve conflicts early
+- Save frequently if you're working on a complex multi-leg itinerary
+- The contact and notes carry through to the quote, so fill them in on the request to save time later


### PR DESCRIPTION
## Summary

- **New page: `creating-a-quote.md`** — Full step-by-step guide covering all 4 stages of the Quote Builder:
  1. **Quote Details** — Contact selection, job notes, total passengers, T&C template selection
  2. **Flights** — Airport search, FBO facility selection, route library, custom airports, multi-leg itineraries, drag-to-reorder, interactive map, return-to-homebase
  3. **Aircraft** — Fleet selection with pricing (customer price + operator cost), charter/ferry times, availability cautions (schedule conflicts), operational cautions (runway/capacity/range), expandable cost breakdown editor, RFQ toggle for external operators
  4. **Quote Summary** — Review with local and Zulu times, create quote

- **Updated `create-a-quote-from-a-request-operators.md`** — Now references the Quote Builder page and explains the pre-fill flow from Requests
- **Updated `README.md`** — Added Quote Builder as the primary link above the existing "from Request" guides
- **Updated `SUMMARY.md`** — Added navigation entry

## Test plan

- [ ] Verify each builder step description matches the actual UI
- [ ] Confirm FBO facility selection and route library flows are accurately described
- [ ] Check availability and operational caution descriptions match what operators see
- [ ] Verify cost breakdown editor section matches the expandable flight details UI
- [ ] Confirm RFQ toggle is accurately described for external aircraft

🤖 Generated with [Claude Code](https://claude.com/claude-code)