### PR TITLE
Fix sending confirmations page accuracy

### DIFF
--- a/guides/bookings-operators/sending-confirmations.md
+++ b/guides/bookings-operators/sending-confirmations.md
@@ -1,134 +1,124 @@
 ---
-description: Send booking confirmations and updates to customers.
+description: Send booking confirmations and updates to customers, crew, and external operators.
 ---
 
-# 📧 Sending Confirmations
+# Sending Confirmations
 
-The Send section lets you communicate with customers about their booking. Send confirmations, updates, and itineraries directly from AeroQuote.
+The **Send** tab lets you communicate booking details to customers, crew members, and external operators directly from AeroQuote.
 
 ---
 
-## Accessing Send Options
+## Accessing the Send Tab
 
 1. Go to **Bookings** from the sidebar
 2. Click on a booking
 3. Select the **Send** tab
 
+You will see three send buttons at the top of the page:
+
+| Action | Recipients | When to use |
+|--------|-----------|-------------|
+| **Send to Customer** | Main contacts and additional recipients on the booking | After creating or updating a booking |
+| **Send to Crew** | All crew members assigned to the booking | After assigning crew and finalising the itinerary |
+| **Send to External Operators** | External operators whose aircraft are assigned | When using aircraft from another operator |
+
+{% hint style="info" %}
+The **Send to External Operators** button is disabled if no external aircraft are assigned to the booking.
+{% endhint %}
+
 ---
 
-## What You Can Send
+## Sending to Customers
 
-| Document Type | Purpose |
-|---------------|---------|
-| **Booking Confirmation** | Confirms the booking details |
-| **Itinerary** | Flight schedule and details |
-| **Invoice** | Payment request |
-| **Manifest** | Passenger/cargo list |
-| **Updates** | Changes or notifications |
+### Step 1: Review Recipients
 
----
+The Send tab shows two recipient groups pulled from the booking's contact list:
 
-## Sending a Confirmation
+- **Main Contacts** — contacts marked as main contacts on the booking. The designated **Primary Contact** is shown with a badge.
+- **Additional Recipients** — other contacts attached to the booking.
 
-### Step 1: Select Document Type
+{% hint style="warning" %}
+Recipients are the contacts assigned to the booking. You cannot enter custom email addresses — to add a recipient, first add them as a contact on the booking's **Contacts** tab.
+{% endhint %}
 
-Choose what you want to send (e.g., Booking Confirmation).
+### Step 2: Choose Basic or Detailed View
 
-### Step 2: Choose Recipients
+For each contact group, toggle **Send with Detailed View** to control what the customer sees when they click the link in their email:
 
-Select who should receive it:
-- Primary customer contact
-- Additional contacts on the booking
-- Custom email addresses
+- **Basic View** — booking summary with flight itinerary
+- **Detailed View** — includes the passenger list and any amendments marked as visible
 
-### Step 3: Preview
+You can also copy the booking link to your clipboard to share it manually.
 
-Review what will be sent:
-- Check the content is correct
-- Verify recipient details
-- Review any attachments
+### Step 3: Preview and Add Notes
+
+Click **Send to Customer** to open the preview modal. Here you can:
+
+- **Preview** the customer booking view exactly as the recipient will see it
+- **Edit Customer Booking Notes** — add or update notes that appear in the customer's email (e.g. special instructions, payment details, or a personal message)
+- **Include QR code boarding passes** — toggle this on to attach scannable boarding passes for each passenger in the email (requires [Bookings V2](../../whats-new/april-2026.md))
 
 ### Step 4: Send
 
-Click **Send** to deliver the communication.
+Click **Send Now** to deliver the email. The system records when the email was last sent — this timestamp is shown beneath the Send to Customer button.
 
 ---
 
-## Email Templates
+## Sending to Crew
 
-AeroQuote uses templates for communications:
+Click **Send to Crew** to open a preview of the crew booking view. This shows the itinerary grouped by aircraft with crew-specific flight assignments.
 
-- **Subject line** — Includes booking reference
-- **Body** — Professional template with your branding
-- **Attachments** — PDFs of relevant documents
+Crew emails are sent to all crew members assigned to the booking who have an email address on file.
 
-Templates can be customized in Settings → Communications.
+---
+
+## Sending to External Operators
+
+Click **Send to External Operators** to preview the external operator view. This shows only the flights relevant to each external operator's aircraft.
+
+Emails are sent to external operators who have an email address on file.
+
+---
+
+## Customer Booking Notes
+
+You can add custom notes to the customer email. These appear in the email body above the booking link.
+
+- **Per-booking notes** — edit in the send confirmation modal before each send
+- **Default notes** — set a default message for all new bookings in **Settings → Default Units** under the "Default Booking Customer Notes" field
 
 ---
 
 ## Online Booking View
 
-Instead of (or in addition to) email, customers can view bookings online:
+Every customer email includes a secure link to an online booking view. Customers can:
 
-1. Send includes a link to the online booking view
-2. Customer clicks link
-3. Sees real-time booking details
-4. Can view itinerary, status updates
+- View the full itinerary and booking details in their browser
+- See real-time status updates without you needing to resend
+- Download the itinerary PDF
+
+The link is cryptographically signed — no login is required, but only people with the link can access it.
 
 {% hint style="info" %}
-Online booking view keeps customers informed without you sending constant updates.
+The online booking view keeps customers informed without you needing to send constant updates. Share the link once and they can check back any time.
 {% endhint %}
 
 ---
 
-## Resending Communications
-
-Need to send again?
-
-1. Go to Send tab
-2. Select the document type
-3. Choose recipients
-4. Send again
-
-Previous sends are logged in the booking history.
-
----
-
-## Communication History
-
-Track what's been sent:
-
-| Column | Description |
-|--------|-------------|
-| **Date** | When it was sent |
-| **Type** | Confirmation, invoice, etc. |
-| **Recipients** | Who received it |
-| **Status** | Sent, delivered, opened (if tracked) |
-
----
-
-## Sending Updates After Changes
+## Resending After Changes
 
 When you make changes to a booking:
 
 1. Update the booking details
-2. Go to Send tab
-3. Send an updated confirmation
-4. Customer receives current information
+2. Go to the **Send** tab
+3. Click the relevant send button (Customer, Crew, or External Operators)
+4. Review the preview and click **Send Now**
+
+The "Last sent" timestamp beneath each button shows when that communication was most recently sent.
 
 {% hint style="success" %}
 **Communicate changes proactively** — Customers appreciate being informed before they have to ask.
 {% endhint %}
-
----
-
-## Crew Communications
-
-You can send booking details to crew:
-- Flight brief
-- Passenger manifest
-- Route information
-- Special requirements
 
 ---
 
@@ -161,7 +151,7 @@ The operator version includes a **planned vs actual duration** comparison for ea
 * **Green** — Actual duration was shorter than planned
 * **Red** — Actual duration was longer than planned
 
-This helps operators identify flights that consistently run over or under estimated durations, informing future quoting accuracy.
+This helps identify flights that consistently run over or under estimated durations, informing future quoting accuracy.
 
 {% hint style="info" %}
 The completion email is fully automatic — no manual action is required. It fires after the system confirms all block times are recorded, either from flight tracking or from the 2-hour fallback timer.
@@ -171,15 +161,15 @@ The completion email is fully automatic — no manual action is required. It fir
 
 ## Tips
 
-- Send confirmation immediately after booking creation
-- Include clear next steps for the customer
-- Attach relevant documents (itinerary PDF, etc.)
-- Follow up closer to departure with reminders
-- The completion email handles post-flight communication automatically
+- Send the customer confirmation as soon as the booking is created
+- Use **Customer Booking Notes** for payment terms, meeting points, or any message specific to this booking
+- Toggle **Detailed View** on when you want customers to see their passenger list and any amendments
+- The completion email handles post-flight communication automatically — no action needed
 
 ---
 
 ## Next Steps
 
-- [Booking Status](booking-status.md) — Keep status updated
-- [Passengers & Cargo](passengers-and-cargo.md) — Complete the manifest
+- [Booking Status](booking-status.md) — Track and update flight status
+- [Passengers & Cargo](passengers-and-cargo.md) — Manage the passenger and cargo manifest
+- [Crew Assignment](crew-assignment.md) — Assign crew to flights


### PR DESCRIPTION
## Summary
- Rewrote the Sending Confirmations support page to match actual codebase functionality
- Removed incorrect claims: custom email addresses, Settings → Communications template customization, Invoice/Manifest/Updates document types, Communication History with delivery/open tracking
- Added accurate documentation for the three send actions (Customer, Crew, External Operators), Basic/Detailed view toggle, Customer Booking Notes, QR boarding passes, and online booking view

## Changes
| Removed (inaccurate) | Replaced with |
|---|---|
| Custom email addresses as recipients | Recipients come from booking contacts only |
| Document type picker (Invoice, Manifest, etc.) | Three send buttons: Customer, Crew, External Operators |
| Settings → Communications template customization | Customer Booking Notes (per-booking + default in Settings → Default Units) |
| Communication History table with delivery/open tracking | "Last sent" timestamps per send action |

🤖 Generated with [Claude Code](https://claude.com/claude-code)