### PR TITLE
docs: document distinction between main Contacts and passenger-type contacts

### DIFF
--- a/getting-started/concepts.md
+++ b/getting-started/concepts.md
@@ -44,6 +44,8 @@ Assign crew from your user database to a Booking. Once an allocation has been ma
 
 Add passenger information and assign them to some or all of the flight legs. Passenger details like contact information and weights are available to view for you and your crew assigned to the booking.
 
+New passengers added here (without linking an existing contact) are stored as "passenger"-type Contacts. These can be viewed and filtered separately in the main Contacts list (see [Contacts](concepts.md#contacts) and the [Passengers & Cargo guide](../guides/bookings-operators/passengers-and-cargo.md)).
+
 #### Job Status
 
 You may update the status of a job from **Boarding** -> **In-Progress** -> **Completed** or **Cancelled.**

--- a/getting-started/create-your-first-quote.md
+++ b/getting-started/create-your-first-quote.md
@@ -18,8 +18,8 @@ Before creating a quote, ensure you have:
 
 ## Step 2: Add Customer Details
 
-* **Contact** — Search for an existing contact or click **Add New Contact** to create one
-* **Passengers** — Enter the expected passenger count
+* **Contact** — Search for an existing *main contact* or click **Add New Contact** to create one (these are your primary CRM entries)
+* **Passengers** — Enter the expected passenger count (new passengers added later in a booking are stored as a distinct "passenger" type contact — see the [Contacts](../guides/contacts/README.md) guide for details on the distinction)
 * **Notes** — Add any relevant details (special requirements, luggage, etc.)
 
 ## Step 3: Add Flight Legs

--- a/guides/bookings-operators/passengers-and-cargo.md
+++ b/guides/bookings-operators/passengers-and-cargo.md
@@ -33,6 +33,8 @@ Click **Add Passenger** to open the passenger form.
 | **Phone**   | No       | Contact number                           |
 | **Notes**   | No       | Special requirements, preferences        |
 
+**Note:** If you enter details for a *new* passenger (without selecting an existing contact), AeroQuote creates a new **Contact** record with type `passenger`. These are visible in the main **Contacts** list when filtered to "Passengers" (see [Contacts](../contacts/README.md) for the distinction between main contacts and passenger-type contacts). Existing main contacts can also be selected and used as passengers.
+
 ### Step 3: Assign to Flights
 
 Select which flight legs this passenger is on:

--- a/guides/contacts/README.md
+++ b/guides/contacts/README.md
@@ -1,7 +1,8 @@
 ---
 description: >-
-  Contacts are used as the main point of contact for quotes and bookings.  They
-  are also your passenger database.
+  Contacts serve as your main CRM entries for quotes and bookings, while
+  Passengers are a distinct "passenger" type used for flight manifests and
+  assignments.
 cover: >-
   https://images.unsplash.com/photo-1454923634634-bd1614719a7b?crop=entropy&cs=srgb&fm=jpg&ixid=M3wxOTcwMjR8MHwxfHNlYXJjaHw0fHxjcm93ZHxlbnwwfHx8fDE2OTI3MDUyOTJ8MA&ixlib=rb-4.0.3&q=85
 coverY: 0
@@ -9,13 +10,18 @@ coverY: 0
 
 # Contacts
 
+AeroQuote distinguishes between two types of contacts:
+
+- **Main Contacts** (type: `contact`): Your primary customer relationship management (CRM) database. These are used as the main point of contact for quotes and bookings, quote history, CSV imports, quick search, and customer communications.
+- **Passengers** (type: `passenger`): Special-purpose contacts used for passenger manifests, flight leg assignments, weights for payload calculations, check-in, and crew views. 
+
+New passengers added via the **Passengers & Cargo** step in a booking (when not linking to an existing contact) are automatically created as passenger-type contacts. These appear in the Contacts list when you filter by **Passengers**. You can also use existing main contacts as passengers on bookings.
+
 {% hint style="info" %}
-If you use a contact as a passenger, you should edit the contact weight so payload calculations are accurate.
+If you use a contact (main or passenger) as a passenger, edit the contact's weight for accurate payload calculations. Passenger-type contacts are ideal for one-off or manifest-specific entries to avoid cluttering your main CRM list.
 {% endhint %}
 
-<details>
-
-<summary>Listing all Contacts</summary>
+## Listing and Filtering Contacts
 
 Click the <img src="../../.gitbook/assets/contacts menu item.png" alt="" data-size="line"> Contacts menu item to open the list of contacts.
 
@@ -23,12 +29,11 @@ Click the <img src="../../.gitbook/assets/contacts menu item.png" alt="" data-si
 
 From this page, you can:
 
-* **Add new Contact** - Click this button to add a new contact. [See how](add-a-new-contact.md)
-* **Import CSV** - use this feature to upload a CSV of contacts. [See how](import-contacts.md)
+* **Add new Contact** - Click this button to add a new *main* contact. [See how](add-a-new-contact.md)
+* **Import CSV** - Bulk import main contacts from spreadsheets. [See how](import-contacts.md)
+* **Filter by type** — Use the **Show:** filter buttons (All / Contacts / Passengers) to view main contacts, passenger-type contacts, or both.
 * **Search** - search for contacts by name, email, company name, phone, or notes.
 * Edit a Contact - click the <img src="../../.gitbook/assets/contact edit button.png" alt="" data-size="line">button to open the edit contact window.
-
-</details>
 
 {% content-ref url="add-a-new-contact.md" %}
 [add-a-new-contact.md](add-a-new-contact.md)

--- a/guides/contacts/add-a-new-contact.md
+++ b/guides/contacts/add-a-new-contact.md
@@ -1,5 +1,9 @@
 # Add a new contact
 
-Watch the interactive demo to learn how to add a new contact.
+This creates a **main contact** (type: `contact`) for use in your CRM, as the primary point of contact on quotes and bookings, etc.
+
+Passengers added directly in the booking **Passengers & Cargo** step (without selecting an existing contact) are created as a separate **passenger** type. See the main [Contacts](README.md) page for details on the distinction and filtering in the list.
+
+Watch the interactive demo to learn how to add a new (main) contact.
 
 {% @arcade/embed flowId="Ax3N6blamgae06Jm8qn8" url="https://app.arcade.software/share/Ax3N6blamgae06Jm8qn8" %}

--- a/guides/contacts/import-contacts.md
+++ b/guides/contacts/import-contacts.md
@@ -1,6 +1,8 @@
 # Import contacts
 
-You can import contacts in bulk by uploading a CSV file.
+You can import **main contacts** (type: `contact`) in bulk by uploading a CSV file. These become part of your primary CRM database for use on quotes, bookings as main contacts, etc.
+
+Passenger-type contacts are typically created automatically when adding new passengers in the **Passengers & Cargo** step of bookings (or via public scheduled flights / tour storefronts). See the main [Contacts](README.md) page for the full distinction between main contacts and passengers, and how to filter the list.
 
 {% hint style="warning" %}
 The CSV file must be correctly formatted, otherwise, AeroQuote may reject the entries.  For a sample CSV,[ download one here](https://cdn.aeroquote.com/sample-assets/aeroquote_contact_import_example.csv).

--- a/overview/our-features.md
+++ b/overview/our-features.md
@@ -86,12 +86,12 @@ Source aircraft from your network of operators.
 
 ## 👥 Contacts & CRM
 
-Keep your customer data organized.
+Keep your customer data organized. AeroQuote distinguishes two contact types:
 
-- **Contact Database** — Store customer details and preferences
-- **CSV Import** — Bulk import contacts from spreadsheets
-- **Quote History** — See all quotes and bookings per contact
-- **Quick Search** — Find contacts instantly
+- **Main Contacts** (type: `contact`) — Your primary CRM database for customer details, preferences, CSV import, quote/booking history per contact, and quick search.
+- **Passengers** (type: `passenger`) — Special contacts for manifests, flight assignments, weights, and check-in. New passengers added in the Passengers & Cargo step of a booking (without linking an existing contact) are created as this type. Filter the Contacts list to view "Passengers" separately.
+
+See the [Contacts guide](../guides/contacts/README.md) for details.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates support documentation to clearly describe the two roles of Contacts in AeroQuote, based on recent internal improvements to contact management:

- **Main Contacts** (type: `contact`): Primary CRM entries used for customer details, preferences, quotes, bookings as the main contact, CSV import, history, etc.
- **Passengers** (type: `passenger`): Distinct contacts used for passenger manifests, flight leg assignments, weights/payload, check-in, and crew views.

### Key changes
- New passengers added via the **Passengers & Cargo** step in a booking (without selecting/linking an existing contact) are now automatically created/stored as `passenger`-type contacts.
- These are visible (and filterable) in the main **Contacts** list by selecting the "Passengers" filter (new UI filter added: All / Contacts / Passengers).
- Existing main contacts can still be selected and used as passengers.
- Similar logic applies when passengers are materialized from public scheduled flights (`/fly/{slug}`) and tour package storefronts.
- The Contacts list and related flows now better separate these to avoid cluttering the main CRM view with every passenger ever added.

Updated pages:
- `guides/contacts/README.md` (main overview + listing/filtering)
- `guides/contacts/add-a-new-contact.md`
- `guides/contacts/import-contacts.md`
- `overview/our-features.md` (Contacts & CRM section)
- `guides/bookings-operators/passengers-and-cargo.md`
- `getting-started/concepts.md`
- `getting-started/create-your-first-quote.md`

See the corresponding internal changes around the `Contact` model `type` field, `ListContacts` component, passenger form/assignment in bookings, and confirm/purchase actions for scheduled flights and tours.

## Related
Internal work introduced the type distinction and UI filter for better separation of concerns in contact management.