### PR TITLE
Flight tracking docs: inference defers to live FR24 detection; evidence-based expiry

### DIFF
--- a/guides/bookings-operators/flight-tracking/automatic-detection.md
+++ b/guides/bookings-operators/flight-tracking/automatic-detection.md
@@ -36,6 +36,8 @@ flowchart LR
 
 AeroQuote starts looking for departures from shortly before scheduled time through several hours after — and continues watching **stalled rotation legs** (multi-leg bookings in Ground Time) for up to **two days** after a leg's scheduled departure.
 
+Legs whose departure was **inferred** from the schedule stay in this watch too — if FR24 later detects the aircraft, the estimated time is replaced with the **real takeoff time** from the flight record.
+
 ### Mid-leg coverage recovery
 
 In remote areas ADS-B coverage often **starts mid-route**. When FR24 first shows an aircraft clearly **between** the leg's departure and arrival airports (but not at the gate), AeroQuote:

--- a/guides/bookings-operators/flight-tracking/multi-leg-rotations.md
+++ b/guides/bookings-operators/flight-tracking/multi-leg-rotations.md
@@ -42,13 +42,20 @@ If FR24 shows the aircraft en route on leg 2's corridor, departure is recorded e
 
 If the rotation **stalled** — a leg never got departure/arrival but the booking clearly flew — AeroQuote can fill missing milestones from the **schedule** (each leg's `occurring_at` and `duration`).
 
+Inferred times respect what actually happened: when an earlier leg ran late, the following legs shift to the **real arrival plus a minimum turnaround** — a leg is never shown departing before the aircraft had landed from the previous one.
+
 **Inference only runs when there is real evidence** on the booking:
 
 * FR24 or FlightAware on a milestone, or
 * Crew manual / GPS confirmation, or
 * At least one FR24 position stored on any leg
 
-Inferred times are labelled **(estimated)** in the Status tab and can be overwritten by crew or better FR24 data later.
+**Inference waits when live detection is likely:**
+
+* If the previous leg's arrival was tracked **down to the surface** (good ADS-B coverage at that airport), the next departure is left for FR24 to detect — for up to **six hours** past the expected departure, after which inference proceeds so the booking still resolves
+* Nothing is inferred while the aircraft has an FR24 sighting in the last **30 minutes** — live tracking takes over
+
+Inferred times are labelled **(estimated)** in the Status tab. Crew updates always overwrite them, and AeroQuote keeps watching FR24 for estimated legs — if the aircraft is detected, the estimate is replaced with the **real takeoff time** automatically.
 
 A background job checks stalled bookings every **10 minutes** after the booking's end time.
 
@@ -79,7 +86,7 @@ You receive a **warning email** around 12 hours before the 24-hour cutoff if the
 With leg 1 confirmed by FR24, AeroQuote can:
 
 * Recover leg 2 via mid-route sighting
-* Infer legs 3–4 times from schedule after the rotation ends
+* Infer legs 3–4 times from schedule after the rotation ends — shifted to match any delay, and waiting for real detection first where coverage is good
 * Mark the booking **Completed** instead of **Expired**
 
 Without any FR24 or crew evidence, inference does not run — operators should record times manually on the mobile app.

--- a/guides/bookings-operators/flight-tracking/multi-leg-rotations.md
+++ b/guides/bookings-operators/flight-tracking/multi-leg-rotations.md
@@ -65,8 +65,10 @@ If a booking sits in **Confirmed** or **Ground Time** for more than **24 hours a
 
 | Situation | Outcome |
 | --- | --- |
-| **No leg ever departed** | Booking → **Expired** (operator emailed; can revert to Confirmed) |
-| **At least one leg departed** | Remaining legs inferred when evidence exists → booking → **Completed** (not expired) |
+| **No evidence any leg flew** | Booking → **Expired** (operator emailed; can revert to Confirmed) |
+| **FR24 or crew evidence a flight occurred** | Missing legs inferred → booking → **Completed** (not expired) |
+
+Auto-run departures on their own are **not** evidence — a booking that only progressed on the timetable, with no FR24 sighting or crew confirmation, still expires.
 
 {% hint style="info" %}
 You receive a **warning email** around 12 hours before the 24-hour cutoff if the booking is still open — time to confirm legs manually or verify tracking identifiers.


### PR DESCRIPTION
Updates the Flight Tracking guides for the inference improvements shipped in aeroquote `71e0f278` and `6d8c2881`:

- **Multi-leg Rotations** — inferred times are now clamped to the preceding leg's actual arrival plus a minimum turnaround; inference defers when the previous arrival was tracked to the surface (up to six hours) and stands down entirely while the aircraft has a fresh FR24 sighting; FR24 detection now genuinely replaces estimates automatically.
- **Multi-leg Rotations (completion vs expiry)** — the 24-hour outcome now hinges on flight evidence: FR24 or crew evidence → Completed, no evidence → Expired. Auto-run departures alone are not evidence.
- **Automatic Detection** — the two-day stalled-leg watch also covers inferred departures, upgrading schedule guesses to real takeoff times.

**Hold merging until the code is deployed to production** — beta has the first commit now (the evidence-based expiry change is committed but not yet pushed); these pages describe behaviour production won't have until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ms6Ac3Kh9bXmVAaruLmZ5k